### PR TITLE
corrected_to_take_full_string_for_nested_parameters

### DIFF
--- a/system_modes/src/system_modes/mode_impl.cpp
+++ b/system_modes/src/system_modes/mode_impl.cpp
@@ -112,9 +112,9 @@ void
 ModeImpl::set_parameter(const Parameter & parameter)
 {
   std::string param_name = parameter.get_name();
-  std::size_t foundr = parameter.get_name().rfind(".");
+  std::size_t foundr = parameter.get_name().rfind("ros__parameters");
   if (foundr != std::string::npos) {
-    param_name = parameter.get_name().substr(foundr + 1);
+    param_name = parameter.get_name().substr(foundr + strlen("ros__parameters") + 1);
   }
 
   if (this->param_.find(param_name) == this->param_.end()) {

--- a/system_modes/src/system_modes/mode_inference.cpp
+++ b/system_modes/src/system_modes/mode_inference.cpp
@@ -539,9 +539,9 @@ ModeInference::add_param_to_mode(ModeBasePtr mode, const Parameter & param)
 {
   // TODO(anordman): All of this has to be easier
   std::string param_name = param.get_name();
-  std::size_t foundr = param.get_name().rfind(".");
+  std::size_t foundr = param.get_name().rfind("ros__parameters");
   if (foundr != std::string::npos) {
-    param_name = param_name.substr(foundr + 1);
+    param_name = param_name.substr(foundr + strlen("ros__parameters") + 1);
   }
   auto paramMsg = param.to_parameter_msg();
   paramMsg.name = param_name;


### PR DESCRIPTION
corrected to take the full name of the nested parameters mentioned in modes.