### PR TITLE
Use ament_target_dependencies to link boost_program_options

### DIFF
--- a/system_modes/CMakeLists.txt
+++ b/system_modes/CMakeLists.txt
@@ -53,6 +53,7 @@ ament_target_dependencies(mode
   "rosidl_typesupport_cpp"
   "std_msgs"
   "Boost"
+  "Boost_PROGRAM_OPTIONS"
   "builtin_interfaces"
 )
 #rosidl_target_interfaces(mode
@@ -60,7 +61,7 @@ ament_target_dependencies(mode
 # TODO Should work with the two lines above, but doesn't
 include_directories(../../build/system_modes/rosidl_generator_cpp/)
 link_directories(../../build/system_modes/)
-target_link_libraries(mode system_modes__rosidl_typesupport_cpp boost_program_options)
+target_link_libraries(mode system_modes__rosidl_typesupport_cpp)
 
   # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.


### PR DESCRIPTION
`find_package(Boost)` may pass file paths for Boost libraries which may not be present in the default search locations at link time, so `target_link_libraries(... boost_program_options)` may not always work.

Since `FindBoost.cmake` sets `Boost_<C>_FOUND` and `Boost_<C>_LIBRARIES` for each requested component, we can let `ament_target_dependencies()` discover the component as if it were a standalone package.

https://github.com/Kitware/CMake/blob/efa30023b4056a4c17e80d7a86bc2506660c68a7/Modules/FindBoost.cmake#L30-L32