### PR TITLE
Replace API deprecated in Foxy

### DIFF
--- a/system_modes_examples/src/drive_base.cpp
+++ b/system_modes_examples/src/drive_base.cpp
@@ -66,7 +66,7 @@ public:
       }
       return result;
     };
-    this->set_on_parameters_set_callback(param_change_callback);
+    param_change_callback_handle_ = this->add_on_set_parameters_callback(param_change_callback);
   }
 
   DriveBase(const DriveBase &) = delete;
@@ -103,6 +103,9 @@ public:
 
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   };
+
+private:
+  rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr param_change_callback_handle_;
 };
 
 }  // namespace examples

--- a/system_modes_examples/src/manipulator.cpp
+++ b/system_modes_examples/src/manipulator.cpp
@@ -63,7 +63,7 @@ public:
       }
       return result;
     };
-    this->set_on_parameters_set_callback(param_change_callback);
+    param_change_callback_handle_ = this->add_on_set_parameters_callback(param_change_callback);
   }
 
   Manipulator(const Manipulator &) = delete;
@@ -100,6 +100,9 @@ public:
 
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   };
+
+private:
+  rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr param_change_callback_handle_;
 };
 
 }  // namespace examples


### PR DESCRIPTION
Since the deprecated API was removed in Rolling, this change should fix the failure here: http://build.ros2.org/view/Rbin_uF64/job/Rbin_uF64__system_modes_examples__ubuntu_focal_amd64__binary/12/