### PR TITLE
Removes redundancy from mode services

### DIFF
--- a/system_modes/changelog.rst
+++ b/system_modes/changelog.rst
@@ -2,7 +2,12 @@
 Changelog for package system_modes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.2.3 (2020-02-13)
+0.3.0 (2020-07-23)
+-----------
+* changed mode service specifications (less redundancy)
+* https://github.com/micro-ROS/system_modes/issues/24
+
+0.2.3 (2020-07-23)
 -----------
 * improved StateAndMode struct
 * testing

--- a/system_modes/include/system_modes/mode_manager.hpp
+++ b/system_modes/include/system_modes/mode_manager.hpp
@@ -65,26 +65,30 @@ protected:
 
   // Mode service callbacks
   virtual void on_change_mode(
-    const std::shared_ptr<rmw_request_id_t>,
+    const std::string &,
     const std::shared_ptr<system_modes::srv::ChangeMode::Request>,
     std::shared_ptr<system_modes::srv::ChangeMode::Response>);
   virtual void on_get_mode(
-    const std::shared_ptr<rmw_request_id_t>,
-    const std::shared_ptr<system_modes::srv::GetMode::Request>,
+    const std::string &,
     std::shared_ptr<system_modes::srv::GetMode::Response>);
   virtual void on_get_available_modes(
-    const std::shared_ptr<rmw_request_id_t>,
-    const std::shared_ptr<system_modes::srv::GetAvailableModes::Request>,
+    const std::string &,
     std::shared_ptr<system_modes::srv::GetAvailableModes::Response>);
 
   virtual bool change_state(
-    const std::string & node,
+    const std::string &,
     unsigned int,
     bool transitive = true);
-  virtual bool change_mode(const std::string & node, const std::string & mode);
+  virtual bool change_mode(
+    const std::string &,
+    const std::string &);
 
-  virtual void change_part_state(const std::string & node, unsigned int);
-  virtual void change_part_mode(const std::string & node, const std::string & mode);
+  virtual void change_part_state(
+    const std::string &,
+    unsigned int);
+  virtual void change_part_mode(
+    const std::string &,
+    const std::string &);
 
 private:
   std::shared_ptr<ModeInference> mode_inference_;

--- a/system_modes/package.xml
+++ b/system_modes/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>system_modes</name>
-  <version>0.2.3</version>
+  <version>0.3.0</version>
   <description>Model-based distributed configuration handling.</description>
   <maintainer email="arne.nordmann@bosch.com">Arne Nordmann</maintainer>
   <license>Apache License 2.0</license>

--- a/system_modes/src/mode_monitor_node.cpp
+++ b/system_modes/src/mode_monitor_node.cpp
@@ -103,9 +103,6 @@ bool parseOptions(int argc, char * argv[])
     return true;
   }
 
-  // if (modelfile.empty()) {
-  //   throw invalid_argument("Need path to model file.");
-  // }
   return false;
 }
 
@@ -121,7 +118,7 @@ void mode_change_callback(
   const string & node_name)
 {
   monitor->inference()->update_state(node_name, State::PRIMARY_STATE_ACTIVE);
-  monitor->inference()->update_mode(node_name, msg->goal_mode.label.c_str());
+  monitor->inference()->update_mode(node_name, msg->goal_mode.label);
 }
 
 void transition_request_callback(
@@ -145,7 +142,7 @@ void mode_request_callback(
 {
   monitor->inference()->update_target(
     node_name,
-    StateAndMode(State::PRIMARY_STATE_ACTIVE, msg->goal_mode.label.c_str()));
+    StateAndMode(State::PRIMARY_STATE_ACTIVE, msg->goal_mode.label));
 }
 
 void

--- a/system_modes/src/system_modes/mode_manager.cpp
+++ b/system_modes/src/system_modes/mode_manager.cpp
@@ -47,6 +47,7 @@ using lifecycle_msgs::srv::ChangeState;
 using lifecycle_msgs::srv::GetAvailableStates;
 
 using system_modes::msg::ModeEvent;
+using system_modes::srv::GetMode;
 using system_modes::srv::ChangeMode;
 using system_modes::srv::GetAvailableModes;
 
@@ -137,18 +138,32 @@ ModeManager::add_system(const std::string & system)
 
   // Mode services
   service_name = system + "/change_mode";
+  std::function<void(const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<ChangeMode::Request>,
+    std::shared_ptr<ChangeMode::Response>)> mode_change_callback =
+    std::bind(&ModeManager::on_change_mode, this, system, _2, _3);
   this->mode_change_srv_[system] = this->create_service<ChangeMode>(
-    service_name, std::bind(&ModeManager::on_change_mode, this, _1, _2, _3));
+    service_name,
+    mode_change_callback);
 
   service_name = system + "/get_mode";
+  std::function<void(const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<GetMode::Request>,
+    std::shared_ptr<GetMode::Response>)> mode_get_callback =
+    std::bind(&ModeManager::on_get_mode, this, system, _3);
   this->get_mode_srv_[system] =
     this->create_service<system_modes::srv::GetMode>(
     service_name,
-    std::bind(&ModeManager::on_get_mode, this, _1, _2, _3));
+    mode_get_callback);
 
   service_name = system + "/get_available_modes";
+  std::function<void(const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<GetAvailableModes::Request>,
+    std::shared_ptr<GetAvailableModes::Response>)> mode_avail_callback =
+    std::bind(&ModeManager::on_get_available_modes, this, system, _3);
   this->modes_srv_[system] = this->create_service<GetAvailableModes>(
-    service_name, std::bind(&ModeManager::on_get_available_modes, this, _1, _2, _3));
+    service_name,
+    mode_avail_callback);
 
   // Lifecycle change clients
   service_name = system + "/change_state";
@@ -174,18 +189,32 @@ ModeManager::add_node(const std::string & node)
 
   // Mode services
   service_name = node + "/change_mode";
+  std::function<void(const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<ChangeMode::Request>,
+    std::shared_ptr<ChangeMode::Response>)> mode_change_callback =
+    std::bind(&ModeManager::on_change_mode, this, node, _2, _3);
   this->mode_change_srv_[node] = this->create_service<ChangeMode>(
-    service_name, std::bind(&ModeManager::on_change_mode, this, _1, _2, _3));
+    service_name,
+    mode_change_callback);
 
   service_name = node + "/get_mode";
+  std::function<void(const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<GetMode::Request>,
+    std::shared_ptr<GetMode::Response>)> mode_get_callback =
+    std::bind(&ModeManager::on_get_mode, this, node, _3);
   this->get_mode_srv_[node] =
     this->create_service<system_modes::srv::GetMode>(
     service_name,
-    std::bind(&ModeManager::on_get_mode, this, _1, _2, _3));
+    mode_get_callback);
 
   service_name = node + "/get_available_modes";
+  std::function<void(const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<GetAvailableModes::Request>,
+    std::shared_ptr<GetAvailableModes::Response>)> mode_avail_callback =
+    std::bind(&ModeManager::on_get_available_modes, this, node, _3);
   this->modes_srv_[node] = this->create_service<GetAvailableModes>(
-    service_name, std::bind(&ModeManager::on_get_available_modes, this, _1, _2, _3));
+    service_name,
+    mode_avail_callback);
 
   // Lifecycle change clients
   service_name = node + "/change_state";
@@ -278,31 +307,30 @@ ModeManager::on_get_available_states(
 
 void
 ModeManager::on_change_mode(
-  const std::shared_ptr<rmw_request_id_t>,
+  const std::string & node_name,
   const std::shared_ptr<ChangeMode::Request> request,
   std::shared_ptr<ChangeMode::Response> response)
 {
   RCLCPP_INFO(
     this->get_logger(),
     "-> callback change_mode of %s to %s",
-    request->node_name.c_str(),
+    node_name.c_str(),
     request->mode_name.c_str());
 
   // We can't wait for the state/mode transitions
-  response->success = this->change_mode(request->node_name, request->mode_name);
+  response->success = this->change_mode(node_name, request->mode_name);
 }
 
 void
 ModeManager::on_get_mode(
-  const std::shared_ptr<rmw_request_id_t>,
-  const std::shared_ptr<system_modes::srv::GetMode::Request> request,
+  const std::string & node_name,
   std::shared_ptr<system_modes::srv::GetMode::Response> response)
 {
   // TODO(anordman): to be on the safe side, don't use the node name from
   //       the request, but bind it to the callback instead
-  RCLCPP_INFO(this->get_logger(), "-> callback get_mode of %s", request->node_name.c_str());
+  RCLCPP_INFO(this->get_logger(), "-> callback get_mode of %s", node_name.c_str());
   try {
-    auto stateAndMode = this->mode_inference_->infer(request->node_name);
+    auto stateAndMode = this->mode_inference_->infer(node_name);
     response->current_mode = stateAndMode.mode;
   } catch (std::exception & ex) {
     response->current_mode = "unknown";
@@ -312,8 +340,7 @@ ModeManager::on_get_mode(
 
 void
 ModeManager::on_get_available_modes(
-  const std::shared_ptr<rmw_request_id_t>,
-  const std::shared_ptr<GetAvailableModes::Request> request,
+  const std::string & node_name,
   std::shared_ptr<GetAvailableModes::Response> response)
 {
   // TODO(anordman): to be on the safe side, don't use the node name from
@@ -321,9 +348,9 @@ ModeManager::on_get_available_modes(
   RCLCPP_INFO(
     this->get_logger(),
     "-> callback get_available_modes of %s",
-    request->node_name.c_str());
+    node_name.c_str());
   try {
-    response->available_modes = mode_inference_->get_available_modes(request->node_name);
+    response->available_modes = mode_inference_->get_available_modes(node_name);
   } catch (std::exception & ex) {
     RCLCPP_INFO(this->get_logger(), " unknown");
   }

--- a/system_modes/srv/ChangeMode.srv
+++ b/system_modes/srv/ChangeMode.srv
@@ -1,4 +1,3 @@
-string node_name
 string mode_name
 ---
 bool success

--- a/system_modes/srv/GetAvailableModes.srv
+++ b/system_modes/srv/GetAvailableModes.srv
@@ -1,3 +1,2 @@
-string node_name
 ---
 string[] available_modes

--- a/system_modes/srv/GetMode.srv
+++ b/system_modes/srv/GetMode.srv
@@ -1,3 +1,2 @@
-string node_name
 ---
 string current_mode

--- a/system_modes_examples/README.md
+++ b/system_modes_examples/README.md
@@ -50,15 +50,15 @@ In an additional fifth terminal, you may mimic a planning/executive component to
   The mode monitor should display the following system state:  
   ![mode_monitor](./doc/screenshot-monitor-active.png "Screenshot of the mode monitor")  
 1. Set your system into *PERFORMANCE* mode with the following ROS 2 command:  
-  $ `ros2 service call /actuation/change_mode system_modes/ChangeMode "{node_name: 'actuation', mode_name: 'PERFORMANCE'}"`  
+  $ `ros2 service call /actuation/change_mode system_modes/ChangeMode "{mode_name: 'PERFORMANCE'}"`  
   To change the *actuation* system into its *PERFORMANCE* mode, the mode manager will change the *drive\_base* to *FAST* mode and activate the *manipulator* node in its *STRONG* mode.
   The mode monitor should display the following system state:  
   ![mode_monitor](./doc/screenshot-monitor-performance.png "Screenshot of the mode monitor")
   Note, that the system state and mode as well as the node modes are indicated to be *inferred*, as explained in the [mode inference](../system_modes/README.md#mode-inference) section of the [system_modes](../system_modes/) package.
 1. You can further play around with the mode inference. For example, change the mode of the two nodes explicitly so that the target mode and actual mode of the *actuation* system diverge. Execute the following two ROS 2 commands:  
-  $ `ros2 service call /drive_base/change_mode system_modes/ChangeMode "{node_name: 'drive_base', mode_name: 'SLOW'}"`  
+  $ `ros2 service call /drive_base/change_mode system_modes/ChangeMode "{mode_name: 'SLOW'}"`  
   and  
-  $ `ros2 service call /manipulator/change_mode system_modes/ChangeMode "{node_name: 'manipulator', mode_name: 'WEAK'}"`  
+  $ `ros2 service call /manipulator/change_mode system_modes/ChangeMode "{mode_name: 'WEAK'}"`  
   The mode monitor should display the following system state:
   ![mode_monitor](./doc/screenshot-monitor-moderate.png "Screenshot of the mode monitor")
   Note, that the mode monitor is able to infer that the system's *actual* mode is now *MODERATE*. This is based on the fact that both its nodes are active, the *drive\_base* is in its *SLOW* mode, and the manipulator is in its *WEAK* mode. However, the last requested mode for the *actuation* system is *PERFORMANCE*, so the monitor infers that the system is still transitioning into its target mode, indicating that the actual system state is *activating* (see [lifecycle](../system_modes/README.md#lifecycle)).

--- a/system_modes_examples/changelog.rst
+++ b/system_modes_examples/changelog.rst
@@ -2,7 +2,12 @@
 Changelog for package system_modes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.2.3 (2020-02-13)
+0.3.0 (2020-07-23)
+-----------
+* changed mode service specifications (less redundancy)
+* https://github.com/micro-ROS/system_modes/issues/24
+
+0.2.3 (2020-07-23)
 -----------
 * improved StateAndMode struct
 * testing

--- a/system_modes_examples/package.xml
+++ b/system_modes_examples/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>system_modes_examples</name>
-  <version>0.2.3</version>
+  <version>0.3.0</version>
   <description>Simple example system for system_modes package.</description>
   <maintainer email="arne.nordmann@bosch.com">Arne Nordmann</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Removes redundant "node name" field from all mode services (get mode, change mode, get available modes). This justifies a version bump to 0.3.0.