### PR TITLE
Un-boost-ify

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,9 +7,9 @@ jobs:
     name: ament_xmllint
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
-    - uses: ros-tooling/setup-ros@master
-    - uses: ros-tooling/action-ros-lint@master
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/setup-ros@0.0.25
+    - uses: ros-tooling/action-ros2-lint@0.0.6
       with:
         linter: xmllint
         package-name: system_modes system_modes_examples
@@ -22,9 +22,9 @@ jobs:
       matrix:
           linter: [cppcheck, cpplint, uncrustify]
     steps:
-    - uses: actions/checkout@master
-    - uses: ros-tooling/setup-ros@master
-    - uses: ros-tooling/action-ros-lint@master
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/setup-ros@0.0.25
+    - uses: ros-tooling/action-ros2-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
         package-name: system_modes system_modes_examples
@@ -37,9 +37,9 @@ jobs:
       matrix:
         linter: [flake8, pep257]
     steps:
-    - uses: actions/checkout@master
-    - uses: ros-tooling/setup-ros@master
-    - uses: ros-tooling/action-ros-lint@master
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/setup-ros@0.0.25
+    - uses: ros-tooling/action-ros2-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}
         package-name: system_modes system_modes_examples

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test diagnostics
+name: Test system modes
 on:
   pull_request:
   push:
@@ -13,9 +13,10 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
     steps:
-      - uses: ros-tooling/setup-ros@master
-      - uses: ros-tooling/action-ros-ci@master
+      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/action-ros-ci@0.0.15
         with:
           package-name: system_modes system_modes_examples
+          target-ros2-distro: foxy
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/system_modes/CMakeLists.txt
+++ b/system_modes/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
-find_package(Boost 1.58 COMPONENTS program_options REQUIRED)
 
 # generate service
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -52,8 +51,6 @@ ament_target_dependencies(mode
   "lifecycle_msgs"
   "rosidl_typesupport_cpp"
   "std_msgs"
-  "Boost"
-  "Boost_PROGRAM_OPTIONS"
   "builtin_interfaces"
 )
 #rosidl_target_interfaces(mode

--- a/system_modes/include/system_modes/mode_manager.hpp
+++ b/system_modes/include/system_modes/mode_manager.hpp
@@ -40,7 +40,7 @@ namespace system_modes
 class ModeManager : public rclcpp::Node
 {
 public:
-  explicit ModeManager(const std::string & model_path);
+  ModeManager();
   ModeManager(const ModeManager &) = delete;
 
   std::shared_ptr<ModeInference> inference();

--- a/system_modes/include/system_modes/mode_monitor.hpp
+++ b/system_modes/include/system_modes/mode_monitor.hpp
@@ -37,7 +37,7 @@ namespace system_modes
 class ModeMonitor : public rclcpp::Node
 {
 public:
-  ModeMonitor(const std::string & model_path, unsigned int rate, bool verbose, bool clear);
+  ModeMonitor();
   ModeMonitor(const ModeMonitor &) = delete;
 
   std::shared_ptr<ModeInference> inference();

--- a/system_modes/launch/mode_manager.launch.py
+++ b/system_modes/launch/mode_manager.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
 
     node = launch_ros.actions.Node(
         package='system_modes',
-        node_executable='mode_manager',
+        executable='mode_manager',
         parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
         output='screen')
 

--- a/system_modes/launch/mode_manager.launch.py
+++ b/system_modes/launch/mode_manager.launch.py
@@ -21,15 +21,12 @@ import launch_ros.actions
 
 
 def generate_launch_description():
-    launch.actions.DeclareLaunchArgument('modelfile', description='Path to modelfile')
-
-    node = launch_ros.actions.Node(
-        package='system_modes',
-        executable='mode_manager',
-        parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
-        output='screen')
-
-    description = launch.LaunchDescription()
-    description.add_action(node)
-
-    return description
+  return launch.LaunchDescription([
+    launch.actions.DeclareLaunchArgument(
+      'modelfile',
+      description='Path to modelfile'),
+    launch_ros.actions.Node(
+      package='system_modes',
+      executable='mode_manager',
+      parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
+      output='screen')])

--- a/system_modes/launch/mode_manager.launch.py
+++ b/system_modes/launch/mode_manager.launch.py
@@ -21,12 +21,12 @@ import launch_ros.actions
 
 
 def generate_launch_description():
-  return launch.LaunchDescription([
-    launch.actions.DeclareLaunchArgument(
-      'modelfile',
-      description='Path to modelfile'),
-    launch_ros.actions.Node(
-      package='system_modes',
-      executable='mode_manager',
-      parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
-      output='screen')])
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'modelfile',
+            description='Path to modelfile'),
+        launch_ros.actions.Node(
+            package='system_modes',
+            executable='mode_manager',
+            parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
+            output='screen')])

--- a/system_modes/launch/mode_monitor.launch.py
+++ b/system_modes/launch/mode_monitor.launch.py
@@ -15,21 +15,34 @@
 
 import launch
 import launch.actions
-import launch.substitutions
 
 import launch_ros.actions
 
 
 def generate_launch_description():
-    launch.actions.DeclareLaunchArgument('modelfile', description='Path to modelfile')
-
-    node = launch_ros.actions.Node(
+    return launch.LaunchDescription([
+      launch.actions.DeclareLaunchArgument(
+        'modelfile',
+        description='Path to modelfile'),
+      launch.actions.DeclareLaunchArgument(
+        'debug',
+        default_value='false',
+        description='Debug'),
+      launch.actions.DeclareLaunchArgument(
+        'verbose',
+        default_value='false',
+        description='Print mode parametrization'),
+      launch.actions.DeclareLaunchArgument(
+        'rate',
+        default_value='1000',
+        description='Monitor refresh rate in ms'),
+      launch_ros.actions.Node(
         package='system_modes',
         executable='mode_monitor',
-        parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
-        output='screen')
-
-    description = launch.LaunchDescription()
-    description.add_action(node)
-
-    return description
+        parameters=[{
+            'modelfile': launch.substitutions.LaunchConfiguration('modelfile'),
+            'debug': launch.substitutions.LaunchConfiguration('debug'),
+            'verbose': launch.substitutions.LaunchConfiguration('verbose'),
+            'rate': launch.substitutions.LaunchConfiguration('rate')
+            }],
+        output='screen')])

--- a/system_modes/launch/mode_monitor.launch.py
+++ b/system_modes/launch/mode_monitor.launch.py
@@ -21,28 +21,28 @@ import launch_ros.actions
 
 def generate_launch_description():
     return launch.LaunchDescription([
-      launch.actions.DeclareLaunchArgument(
-        'modelfile',
-        description='Path to modelfile'),
-      launch.actions.DeclareLaunchArgument(
-        'debug',
-        default_value='false',
-        description='Debug'),
-      launch.actions.DeclareLaunchArgument(
-        'verbose',
-        default_value='false',
-        description='Print mode parametrization'),
-      launch.actions.DeclareLaunchArgument(
-        'rate',
-        default_value='1000',
-        description='Monitor refresh rate in ms'),
-      launch_ros.actions.Node(
-        package='system_modes',
-        executable='mode_monitor',
-        parameters=[{
-            'modelfile': launch.substitutions.LaunchConfiguration('modelfile'),
-            'debug': launch.substitutions.LaunchConfiguration('debug'),
-            'verbose': launch.substitutions.LaunchConfiguration('verbose'),
-            'rate': launch.substitutions.LaunchConfiguration('rate')
-            }],
-        output='screen')])
+        launch.actions.DeclareLaunchArgument(
+            'modelfile',
+            description='Path to modelfile'),
+        launch.actions.DeclareLaunchArgument(
+            'debug',
+            default_value='false',
+            description='Debug'),
+        launch.actions.DeclareLaunchArgument(
+            'verbose',
+            default_value='false',
+            description='Print mode parametrization'),
+        launch.actions.DeclareLaunchArgument(
+            'rate',
+            default_value='1000',
+            description='Monitor refresh rate in ms'),
+        launch_ros.actions.Node(
+            package='system_modes',
+            executable='mode_monitor',
+            parameters=[{
+                'modelfile': launch.substitutions.LaunchConfiguration('modelfile'),
+                'debug': launch.substitutions.LaunchConfiguration('debug'),
+                'verbose': launch.substitutions.LaunchConfiguration('verbose'),
+                'rate': launch.substitutions.LaunchConfiguration('rate')
+                }],
+            output='screen')])

--- a/system_modes/launch/mode_monitor.launch.py
+++ b/system_modes/launch/mode_monitor.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
 
     node = launch_ros.actions.Node(
         package='system_modes',
-        node_executable='mode_monitor',
+        executable='mode_monitor',
         parameters=[{'modelfile': launch.substitutions.LaunchConfiguration('modelfile')}],
         output='screen')
 

--- a/system_modes/package.xml
+++ b/system_modes/package.xml
@@ -14,7 +14,6 @@
   <depend>std_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>rosidl_default_generators</depend>
-  <depend>libboost-program-options-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/system_modes/src/mode_manager_node.cpp
+++ b/system_modes/src/mode_manager_node.cpp
@@ -18,8 +18,6 @@
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition_event.hpp>
 
-#include <boost/program_options.hpp>
-
 #include <chrono>
 #include <memory>
 #include <string>
@@ -46,46 +44,11 @@ using system_modes::msg::ModeEvent;
 using lifecycle_msgs::msg::State;
 using lifecycle_msgs::msg::TransitionEvent;
 
-using boost::program_options::value;
-using boost::program_options::variables_map;
-using boost::program_options::command_line_parser;
-using boost::program_options::options_description;
-using boost::program_options::positional_options_description;
-
 using rcl_interfaces::msg::ParameterType;
 using rcl_interfaces::msg::ParameterEvent;
 
 string modelfile, loglevel;
-options_description options("Allowed options");
-
 shared_ptr<ModeManager> manager;
-
-bool parseOptions(int argc, char * argv[])
-{
-  options.add_options()("help", "Help message and options")(
-    "modelfile", value<string>(&modelfile),
-    "Path to yaml model file")(
-    "__log_level", value<string>(&loglevel),
-    "ROS2 log level")(
-    "ros-args", value<vector<string>>()->multitoken(), "ROS args")(
-    "params-file", value<vector<string>>()->multitoken(), "ROS params file");
-
-  positional_options_description positional_options;
-  positional_options.add("modelfile", 1);
-
-  variables_map map;
-  store(
-    command_line_parser(argc, argv)
-    .options(options)
-    .positional(positional_options)
-    .run(), map);
-  notify(map);
-
-  if (map.count("help")) {
-    return true;
-  }
-  return false;
-}
 
 void transition_callback(
   const TransitionEvent::SharedPtr msg,
@@ -146,22 +109,6 @@ parameter_event_callback(const ParameterEvent::SharedPtr event)
 int main(int argc, char * argv[])
 {
   using namespace std::placeholders;
-
-  // Handle commandline arguments.
-  try {
-    if (parseOptions(argc, argv)) {
-      cout << "Usage: mode_manager MODELFILE" << std::endl;
-      cout << options;
-      cout << "Or specify the MODELFILE by ROS parameter 'modelfile'." << std::endl << std::endl;
-      return EXIT_SUCCESS;
-    }
-  } catch (const std::exception & e) {
-    cerr << "Error parsing command line: " << e.what() << std::endl;
-    cout << "Usage: mode_manager [MODELFILE]" << std::endl;
-    cout << options;
-    cout << "Or specify the MODELFILE by ROS parameter 'modelfile'." << std::endl << std::endl;
-    return EXIT_FAILURE;
-  }
 
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   rclcpp::init(argc, argv);

--- a/system_modes/src/mode_manager_node.cpp
+++ b/system_modes/src/mode_manager_node.cpp
@@ -113,7 +113,7 @@ int main(int argc, char * argv[])
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   rclcpp::init(argc, argv);
 
-  manager = std::make_shared<ModeManager>(modelfile);
+  manager = std::make_shared<ModeManager>();
 
   vector<shared_ptr<rclcpp::Subscription<TransitionEvent>>>
   state_sub_;

--- a/system_modes/src/mode_monitor_node.cpp
+++ b/system_modes/src/mode_monitor_node.cpp
@@ -18,8 +18,6 @@
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition_event.hpp>
 
-#include <boost/program_options.hpp>
-
 #include <chrono>
 #include <memory>
 #include <string>
@@ -49,13 +47,6 @@ using system_modes::msg::ModeEvent;
 using lifecycle_msgs::msg::State;
 using lifecycle_msgs::msg::TransitionEvent;
 
-using boost::program_options::value;
-using boost::program_options::bool_switch;
-using boost::program_options::variables_map;
-using boost::program_options::command_line_parser;
-using boost::program_options::options_description;
-using boost::program_options::positional_options_description;
-
 using rcl_interfaces::msg::ParameterType;
 using rcl_interfaces::msg::ParameterEvent;
 
@@ -63,51 +54,8 @@ string modelfile, loglevel;
 bool debug = false;
 unsigned int rate = 1000;
 bool verbose = false;
-options_description options("Allowed options");
 
 shared_ptr<system_modes::ModeMonitor> monitor;
-
-bool parseOptions(int argc, char * argv[])
-{
-  options.add_options()("help", "Help message and options")(
-    "modelfile",
-    value<string>(&modelfile), "Path to yaml model file")(
-    "__log_level",
-    value<string>(&loglevel), "ROS 2 log level")(
-    "debug,d", bool_switch(&debug)->default_value(false),
-    "Debug mode (don't clear screen)")(
-    "rate,r", value<unsigned int>(&rate)->default_value(1000),
-    "Update rate in milliseconds")(
-    "verbose,v", bool_switch(&verbose)->default_value(false),
-    "Verbose (displays mode parameters)")(
-    "ros-args", value<vector<string>>()->multitoken(),
-    "ROS args")(
-    "params-file", value<vector<string>>()->multitoken(),
-    "ROS params file");
-
-  positional_options_description positional_options;
-  positional_options.add("modelfile", 1);
-  positional_options.add("debug", 0);
-  positional_options.add("rate", 1);
-  positional_options.add("verbose", 0);
-
-  variables_map map;
-  store(
-    command_line_parser(argc, argv)
-    .options(options)
-    .positional(positional_options)
-    .run(), map);
-  notify(map);
-
-  if (map.count("help")) {
-    return true;
-  }
-
-  // if (modelfile.empty()) {
-  //   throw invalid_argument("Need path to model file.");
-  // }
-  return false;
-}
 
 void transition_callback(
   const TransitionEvent::SharedPtr msg,
@@ -168,22 +116,6 @@ parameter_event_callback(const ParameterEvent::SharedPtr event)
 int main(int argc, char * argv[])
 {
   using namespace std::placeholders;
-
-  // Handle commandline arguments.
-  try {
-    if (parseOptions(argc, argv)) {
-      cout << "Usage: mode_monitor MODELFILE" << endl;
-      cout << options;
-      cout << "Or specify the MODELFILE by ROS parameter 'modelfile'." << std::endl << std::endl;
-      return EXIT_SUCCESS;
-    }
-  } catch (const exception & e) {
-    cerr << "Error parsing command line: " << e.what() << endl;
-    cout << "Usage: mode_monitor MODELFILE" << endl;
-    cout << options;
-    cout << "Or specify the MODELFILE by ROS parameter 'modelfile'." << std::endl << std::endl;
-    return EXIT_FAILURE;
-  }
 
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   rclcpp::init(argc, argv);

--- a/system_modes/src/mode_monitor_node.cpp
+++ b/system_modes/src/mode_monitor_node.cpp
@@ -120,7 +120,7 @@ int main(int argc, char * argv[])
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   rclcpp::init(argc, argv);
 
-  monitor = make_shared<ModeMonitor>(modelfile, rate, verbose, !debug);
+  monitor = make_shared<ModeMonitor>();
 
   vector<shared_ptr<rclcpp::Subscription<TransitionEvent>>>
   state_sub_;

--- a/system_modes/src/system_modes/mode_manager.cpp
+++ b/system_modes/src/system_modes/mode_manager.cpp
@@ -55,7 +55,7 @@ using namespace std::chrono_literals;
 namespace system_modes
 {
 
-ModeManager::ModeManager(const string & model_path)
+ModeManager::ModeManager()
 : Node("__mode_manager"),
   mode_inference_(nullptr),
   state_change_srv_(), get_state_srv_(), states_srv_(),
@@ -64,16 +64,11 @@ ModeManager::ModeManager(const string & model_path)
   state_request_pub_(), mode_request_pub_()
 {
   declare_parameter("modelfile", rclcpp::ParameterValue(std::string("")));
+  std::string model_path = get_parameter("modelfile").as_string();
   if (model_path.empty()) {
-    rclcpp::Parameter parameter = get_parameter("modelfile");
-    std::string alt_model_path = parameter.get_value<rclcpp::ParameterType::PARAMETER_STRING>();
-    if (alt_model_path.empty()) {
-      throw std::invalid_argument("Need path to model file.");
-    }
-    mode_inference_ = std::make_shared<ModeInference>(alt_model_path);
-  } else {
-    mode_inference_ = std::make_shared<ModeInference>(model_path);
+    throw std::invalid_argument("Need path to model file.");
   }
+  mode_inference_ = std::make_shared<ModeInference>(model_path);
 
   for (auto system : this->mode_inference_->get_systems()) {
     this->add_system(system);

--- a/system_modes_examples/CMakeLists.txt
+++ b/system_modes_examples/CMakeLists.txt
@@ -24,7 +24,6 @@ find_package(std_msgs REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
-find_package(Boost 1.58 COMPONENTS program_options REQUIRED)
 find_package(system_modes REQUIRED)
 
 # drive_base
@@ -39,7 +38,6 @@ ament_target_dependencies(drive_base
   "lifecycle_msgs"
   "rosidl_typesupport_cpp"
   "std_msgs"
-  "Boost"
   "system_modes"
 )
 install(TARGETS drive_base
@@ -58,7 +56,6 @@ ament_target_dependencies(manipulator
   "lifecycle_msgs"
   "rosidl_typesupport_cpp"
   "std_msgs"
-  "Boost"
   "system_modes"
 )
 install(TARGETS manipulator

--- a/system_modes_examples/launch/drive_base.launch.py
+++ b/system_modes_examples/launch/drive_base.launch.py
@@ -17,23 +17,15 @@ import ament_index_python.packages
 
 import launch
 import launch.actions
-import launch.launch_description_sources
-import launch.substitutions
 import launch_ros
 
 
 def generate_launch_description():
-    launch.actions.DeclareLaunchArgument('modelfile', description='Path to modelfile')
-    modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
-                 '/example_modes.yaml')
-
-    node = launch_ros.actions.Node(
-        package='system_modes_examples',
-        executable='drive_base',
-        parameters=[{'modelfile': modelfile}],
-        output='screen')
-
-    description = launch.LaunchDescription()
-    description.add_action(node)
-
-    return description
+  default_modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
+                '/example_modes.yaml')
+  return launch.LaunchDescription([
+    launch_ros.actions.Node(
+      package='system_modes_examples',
+      executable='drive_base',
+      parameters=[{'modelfile': default_modelfile}],
+      output='screen')])

--- a/system_modes_examples/launch/drive_base.launch.py
+++ b/system_modes_examples/launch/drive_base.launch.py
@@ -21,11 +21,12 @@ import launch_ros
 
 
 def generate_launch_description():
-  default_modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
-                '/example_modes.yaml')
-  return launch.LaunchDescription([
-    launch_ros.actions.Node(
-      package='system_modes_examples',
-      executable='drive_base',
-      parameters=[{'modelfile': default_modelfile}],
-      output='screen')])
+    default_modelfile = (
+        ament_index_python.packages.get_package_share_directory('system_modes_examples') +
+        '/example_modes.yaml')
+    return launch.LaunchDescription([
+        launch_ros.actions.Node(
+            package='system_modes_examples',
+            executable='drive_base',
+            parameters=[{'modelfile': default_modelfile}],
+            output='screen')])

--- a/system_modes_examples/launch/drive_base.launch.py
+++ b/system_modes_examples/launch/drive_base.launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
 
     node = launch_ros.actions.Node(
         package='system_modes_examples',
-        node_executable='drive_base',
+        executable='drive_base',
         parameters=[{'modelfile': modelfile}],
         output='screen')
 

--- a/system_modes_examples/launch/manipulator.launch.py
+++ b/system_modes_examples/launch/manipulator.launch.py
@@ -17,23 +17,15 @@ import ament_index_python.packages
 
 import launch
 import launch.actions
-import launch.launch_description_sources
-import launch.substitutions
 import launch_ros
 
 
 def generate_launch_description():
-    launch.actions.DeclareLaunchArgument('modelfile', description='Path to modelfile')
-    modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
-                 '/example_modes.yaml')
-
-    node = launch_ros.actions.Node(
-        package='system_modes_examples',
-        executable='manipulator',
-        parameters=[{'modelfile': modelfile}],
-        output='screen')
-
-    description = launch.LaunchDescription()
-    description.add_action(node)
-
-    return description
+  default_modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
+                '/example_modes.yaml')
+  return launch.LaunchDescription([
+    launch_ros.actions.Node(
+      package='system_modes_examples',
+      executable='manipulator',
+      parameters=[{'modelfile': default_modelfile}],
+      output='screen')])

--- a/system_modes_examples/launch/manipulator.launch.py
+++ b/system_modes_examples/launch/manipulator.launch.py
@@ -21,11 +21,12 @@ import launch_ros
 
 
 def generate_launch_description():
-  default_modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
-                '/example_modes.yaml')
-  return launch.LaunchDescription([
-    launch_ros.actions.Node(
-      package='system_modes_examples',
-      executable='manipulator',
-      parameters=[{'modelfile': default_modelfile}],
-      output='screen')])
+    default_modelfile = (
+        ament_index_python.packages.get_package_share_directory('system_modes_examples') +
+        '/example_modes.yaml')
+    return launch.LaunchDescription([
+        launch_ros.actions.Node(
+            package='system_modes_examples',
+            executable='manipulator',
+            parameters=[{'modelfile': default_modelfile}],
+            output='screen')])

--- a/system_modes_examples/launch/manipulator.launch.py
+++ b/system_modes_examples/launch/manipulator.launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
 
     node = launch_ros.actions.Node(
         package='system_modes_examples',
-        node_executable='manipulator',
+        executable='manipulator',
         parameters=[{'modelfile': modelfile}],
         output='screen')
 

--- a/system_modes_examples/package.xml
+++ b/system_modes_examples/package.xml
@@ -12,7 +12,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>system_modes</depend>
-  <depend>libboost-program-options-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
@@ -22,7 +21,7 @@
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Getting rid of all boost dependencies: used boost for command line arguments before, but now all arguments are passed through launch.