### PR TITLE
Publish inferred transitions

### DIFF
--- a/system_modes/include/system_modes/mode_inference.hpp
+++ b/system_modes/include/system_modes/mode_inference.hpp
@@ -54,11 +54,21 @@ public:
   virtual void update_target(const std::string &, StateAndMode);
 
   virtual StateAndMode get(const std::string & part) const;
-  virtual StateAndMode get_or_infer(const std::string & part) const;
+  virtual StateAndMode get_or_infer(const std::string & part);
 
-  virtual StateAndMode infer(const std::string & part) const;
-  virtual StateAndMode infer_system(const std::string & part) const;
-  virtual StateAndMode infer_node(const std::string & part) const;
+  virtual StateAndMode infer(const std::string & part);
+  virtual StateAndMode infer_node(const std::string & part);
+  virtual StateAndMode infer_system(const std::string & part);
+
+  /**
+   * Infers latest transitions of systems
+   *
+   * Returns map of last inferred transitions of systems into new states or
+   * new modes. State transitions of nodes don't have to be inferred, as
+   * nodes publish their state transitions. For nodes, we only need to infer
+   * mode transitions.
+   */
+  virtual Deviation infer_transitions();
 
   virtual StateAndMode get_target(const std::string & part) const;
   virtual ModeConstPtr get_mode(const std::string & part, const std::string & mode) const;
@@ -72,9 +82,8 @@ protected:
   virtual void add_param_to_mode(ModeBasePtr, const rclcpp::Parameter &);
 
 private:
-  StatesMap nodes_, nodes_target_;
-  StatesMap systems_, systems_target_;
-  Deviation systems_transitions_;
+  StatesMap nodes_, nodes_target_, nodes_cache_;
+  StatesMap systems_, systems_target_, systems_cache_;
 
   std::map<std::string, ModeMap> modes_;
   ParametersMap parameters_;
@@ -85,7 +94,8 @@ private:
     param_mutex_;
   mutable std::shared_timed_mutex
     nodes_target_mutex_, systems_target_mutex_;
-  mutable std::shared_timed_mutex systems_transitions_mutex_;
+  mutable std::shared_timed_mutex
+    nodes_cache_mutex_, systems_cache_mutex_;
 };
 
 }  // namespace system_modes

--- a/system_modes/include/system_modes/mode_manager.hpp
+++ b/system_modes/include/system_modes/mode_manager.hpp
@@ -90,6 +90,8 @@ protected:
     const std::string &,
     const std::string &);
 
+  virtual void publish_transitions();
+
 private:
   std::shared_ptr<ModeInference> mode_inference_;
 
@@ -117,16 +119,23 @@ private:
   std::map<std::string, rclcpp::AsyncParametersClient::SharedPtr>
   param_change_clients_;
 
-  // Lifecycle transition request
+  // Lifecycle transition publisher
+  std::map<std::string, rclcpp::Publisher<lifecycle_msgs::msg::TransitionEvent>::SharedPtr>
+  transition_pub_;
   std::map<std::string, rclcpp::Publisher<lifecycle_msgs::msg::TransitionEvent>::SharedPtr>
   state_request_pub_;
 
-  // Mode transition request publisher
+  // Mode transition publisher
+  std::map<std::string, rclcpp::Publisher<system_modes::msg::ModeEvent>::SharedPtr>
+  mode_transition_pub_;
   std::map<std::string, rclcpp::Publisher<system_modes::msg::ModeEvent>::SharedPtr>
   mode_request_pub_;
 
   // Remember states and modes of the systems
   std::map<std::string, StateAndMode> current_modes_;
+
+  // Timer to check for and publish recent transitions
+  rclcpp::TimerBase::SharedPtr transition_timer_;
 };
 
 }  // namespace system_modes

--- a/system_modes/msg/ModeEvent.msg
+++ b/system_modes/msg/ModeEvent.msg
@@ -1,2 +1,8 @@
+# The time point at which this event occurred.
 uint64 timestamp
+
+# The starting mode from which this event transitioned.
+Mode start_mode
+
+# The end mode of this transition event.
 Mode goal_mode


### PR DESCRIPTION
Publishes inferred transitions of node modes and system states+modes.

The main change of this PR is that
1. mode inference can now explicitly infer and record the state/mode changes of systems and the mode changes of nodes, see [ModeInference::infer_transitions](https://github.com/micro-ROS/system_modes/pull/46/files#diff-5cee92e6fcf4add7106cd2aa52ff2c19R664-R671)
1. mode manager publishes these transitions in a regular interval, see [ModeManager::publish_transitions](https://github.com/micro-ROS/system_modes/pull/46/files#diff-d5737908788d1b8f9f51e7dcacdc9214R563-R566) on the same topics that lifecycle nodes use

The effect is that
1. transitions of *systems* are now published and visible in the same way transitions of *nodes* are published anyway (lifecycle nodes do that on their own), namely `/{system name}/transition_event` and
1. *mode* transitions are now published and visible in the same way state transitions are published, namely `/{node or system name}/mode_event`