### PR TITLE
Modes observer

### DIFF
--- a/system_modes/CMakeLists.txt
+++ b/system_modes/CMakeLists.txt
@@ -189,6 +189,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_mode_observer mode)
   endif()
 
+  # mode observer test node
+  add_executable(modes_observer_test_node test/launchtest/modes_observer_test_node.cpp)
+  target_include_directories(modes_observer_test_node PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+  target_link_libraries(modes_observer_test_node mode)
+  install(TARGETS modes_observer_test_node DESTINATION lib/${PROJECT_NAME})
+
   # Launch Tests
   find_package(launch_testing_ament_cmake REQUIRED)
   set(launch_tests
@@ -196,7 +204,8 @@ if(BUILD_TESTING)
     "two_mixed_nodes"               # Mode Manager with Lifecycle and non-Lifecycle Nodes
     "two_independent_hierarchies"   # Mode Manager for two independent hierarchies of nodes
     "manager_and_monitor"           # Mode Manager and Mode Monitor
-    "redundant_mode_changes")       # Ignore redundant mode changes
+    "redundant_mode_changes"        # Ignore redundant mode changes
+    "modes_observer")               # Mode Observer
 
   # Launch Test: Mode Manager with Lifecycle Nodes
   foreach(test_name ${launch_tests})

--- a/system_modes/CMakeLists.txt
+++ b/system_modes/CMakeLists.txt
@@ -180,6 +180,15 @@ if(BUILD_TESTING)
     target_link_libraries(test_mode_monitor mode)
   endif()
 
+  ament_add_gtest(test_mode_observer test/test_mode_observer.cpp)
+  if(TARGET test_mode_observer)
+    target_include_directories(test_mode_observer PUBLIC
+      ${rclcpp_INCLUDE_DIRS}
+      ${CMAKE_CURRENT_BINARY_DIR}/system_modes/
+    )
+    target_link_libraries(test_mode_observer mode)
+  endif()
+
   # Launch Tests
   find_package(launch_testing_ament_cmake REQUIRED)
   set(launch_tests

--- a/system_modes/CMakeLists.txt
+++ b/system_modes/CMakeLists.txt
@@ -41,7 +41,8 @@ add_library(mode SHARED
   src/system_modes/mode.cpp
   src/system_modes/mode_impl.cpp
   src/system_modes/mode_handling.cpp
-  src/system_modes/mode_inference.cpp)
+  src/system_modes/mode_inference.cpp
+  src/system_modes/mode_observer.cpp)
 target_include_directories(mode PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/system_modes/README.md
+++ b/system_modes/README.md
@@ -89,6 +89,12 @@ Since the introduced (sub-)systems are not concrete software entities, their sta
   Before attempting a state or mode change for a system or node, the [mode manager](#mode_manager) publishes information about the request.
   The according topics might need to be *latched* in order to allow nodes to do the inference after joining a running system.
 
+#### Mode Observer
+
+Additionally, the library comprises a *Mode Observer* that serves as a local cache of states and modes of all observed system parts. The mode observer will try to obtain the current state and mode initially via sevrice calls (GetState, GetMode) and subsequently monitors according transitions events and mode events.
+
+The mode observer is supposed to be instantiated within a ROS 2 node to have states and modes available locally for fast access, see this exemplary [ModeObserverNode](https://github.com/micro-ROS/system_modes/blob/master/system_modes/test/launchtest/modes_observer_test_node.cpp) used for testing.
+
 ### Mode Manager
 
 The mode manager is a ROS node that accepts an SHM file (see [above](#system-modes)) as command line parameter. It parses the SHM file and creates the according services, publishers, and subscribers to manage the system and its modes.

--- a/system_modes/include/system_modes/mode_impl.hpp
+++ b/system_modes/include/system_modes/mode_impl.hpp
@@ -90,6 +90,11 @@ struct StateAndMode
     }
     return state_label_(state) + "." + mode;
   }
+
+  bool unknown()
+  {
+    return state == State::PRIMARY_STATE_UNKNOWN;
+  }
 };
 
 class ModeImpl

--- a/system_modes/include/system_modes/mode_observer.hpp
+++ b/system_modes/include/system_modes/mode_observer.hpp
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -32,6 +33,7 @@ namespace system_modes
 {
 
 using std::map;
+using std::mutex;
 using std::string;
 
 using lifecycle_msgs::msg::TransitionEvent;
@@ -88,6 +90,7 @@ protected:
 private:
   std::weak_ptr<rclcpp::Node> node_handle_;
   map<string, StateAndMode> cache_;
+  mutable std::shared_timed_mutex mutex_;
 
   map<string, std::shared_ptr<rclcpp::Subscription<TransitionEvent>>> state_subs_;
   map<string, std::shared_ptr<rclcpp::Subscription<ModeEvent>>> mode_subs_;

--- a/system_modes/include/system_modes/mode_observer.hpp
+++ b/system_modes/include/system_modes/mode_observer.hpp
@@ -53,7 +53,6 @@ class ModeObserver
 {
 public:
   explicit ModeObserver(std::weak_ptr<rclcpp::Node>);
-  ModeObserver(const ModeObserver &) = delete;
   virtual ~ModeObserver() = default;
 
   /**

--- a/system_modes/include/system_modes/mode_observer.hpp
+++ b/system_modes/include/system_modes/mode_observer.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2018 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/microros/system_modes
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <lifecycle_msgs/msg/transition_event.hpp>
+#include <lifecycle_msgs/srv/get_state.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "system_modes/mode.hpp"
+#include "system_modes/msg/mode_event.hpp"
+#include "system_modes/srv/get_mode.hpp"
+
+namespace system_modes
+{
+
+using std::map;
+using std::string;
+
+using lifecycle_msgs::msg::TransitionEvent;
+using lifecycle_msgs::srv::GetState;
+using rclcpp::node_interfaces::NodeBaseInterface;
+using system_modes::msg::ModeEvent;
+using system_modes::srv::GetMode;
+
+/**
+ * Mode observer provides a local system modes cache.
+ *
+ * The mode observer serves as a local system modes cache, instantiated by a node. The mode
+ * observer will initially try to gain current states/modes from all observes entities and will
+ * then continuously monitor transitions to keep up to date.
+ */
+class ModeObserver
+{
+public:
+  explicit ModeObserver(std::weak_ptr<rclcpp::Node>);
+  ModeObserver(const ModeObserver &) = delete;
+  virtual ~ModeObserver() = default;
+
+  /**
+   * Getter for observed state and mode.
+   *
+   * Returns cached observed state and mode for requested system entity (system or node).
+   */
+  virtual StateAndMode
+  get(const string & part_name);
+
+  /**
+   * Add part to list of observed parts.
+   */
+  virtual void
+  observe(const string & part_name);
+
+  /**
+   * Remove part from list of observed parts.
+   */
+  virtual void
+  stop_observing(const string & part_name);
+
+protected:
+  virtual void
+  transition_callback(
+    const TransitionEvent::SharedPtr msg,
+    const string & part_name);
+
+  virtual void
+  mode_event_callback(
+    const ModeEvent::SharedPtr msg,
+    const string & part_name);
+
+private:
+  std::weak_ptr<rclcpp::Node> node_handle_;
+  map<string, StateAndMode> cache_;
+
+  map<string, std::shared_ptr<rclcpp::Subscription<TransitionEvent>>> state_subs_;
+  map<string, std::shared_ptr<rclcpp::Subscription<ModeEvent>>> mode_subs_;
+};
+
+}  // namespace system_modes

--- a/system_modes/src/system_modes/mode_observer.cpp
+++ b/system_modes/src/system_modes/mode_observer.cpp
@@ -74,24 +74,28 @@ ModeObserver::observe(const std::string & part_name)
   std::string topic = part_name + "/get_state";
   auto gsrequest = std::make_shared<GetState::Request>();
   auto stateclient = node_handle_.lock()->create_client<GetState>(topic);
-  auto state = stateclient->async_send_request(gsrequest);
-  if (rclcpp::spin_until_future_complete(node_handle_.lock(), state) ==
-    rclcpp::FutureReturnCode::SUCCESS)
-  {
-    auto result = state.get();
-    cache_[part_name].state = result->current_state.id;
+  if (stateclient->wait_for_service(std::chrono::microseconds(500))) {
+    auto state = stateclient->async_send_request(gsrequest);
+    if (rclcpp::spin_until_future_complete(node_handle_.lock(), state) ==
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
+      auto result = state.get();
+      cache_[part_name].state = result->current_state.id;
+    }
   }
 
   // Initial try to get current mode via service request
   topic = part_name + "/get_mode";
   auto gmrequest = std::make_shared<GetMode::Request>();
   auto modeclient = node_handle_.lock()->create_client<GetMode>(topic);
-  auto mode = modeclient->async_send_request(gmrequest);
-  if (rclcpp::spin_until_future_complete(node_handle_.lock(), mode) ==
-    rclcpp::FutureReturnCode::SUCCESS)
-  {
-    auto result = mode.get();
-    cache_[part_name].mode = result->current_mode;
+  if (modeclient->wait_for_service(std::chrono::microseconds(500))) {
+    auto mode = modeclient->async_send_request(gmrequest);
+    if (rclcpp::spin_until_future_complete(node_handle_.lock(), mode) ==
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
+      auto result = mode.get();
+      cache_[part_name].mode = result->current_mode;
+    }
   }
 
   // Set up transition subscriber and mode event subscriber for continuous observation

--- a/system_modes/src/system_modes/mode_observer.cpp
+++ b/system_modes/src/system_modes/mode_observer.cpp
@@ -57,7 +57,7 @@ ModeObserver::get(const std::string & part_name)
   std::shared_lock<shared_mutex> lock(this->mutex_);
   try {
     return cache_.at(part_name);
-  } catch(const std::exception& e) {
+  } catch (const std::exception & e) {
     std::cerr << e.what() << '\n';
     return StateAndMode();
   }
@@ -76,7 +76,8 @@ ModeObserver::observe(const std::string & part_name)
   auto stateclient = node_handle_.lock()->create_client<GetState>(topic);
   auto state = stateclient->async_send_request(gsrequest);
   if (rclcpp::spin_until_future_complete(node_handle_.lock(), state) ==
-    rclcpp::FutureReturnCode::SUCCESS) {
+    rclcpp::FutureReturnCode::SUCCESS)
+  {
     auto result = state.get();
     cache_[part_name].state = result->current_state.id;
   }
@@ -87,7 +88,8 @@ ModeObserver::observe(const std::string & part_name)
   auto modeclient = node_handle_.lock()->create_client<GetMode>(topic);
   auto mode = modeclient->async_send_request(gmrequest);
   if (rclcpp::spin_until_future_complete(node_handle_.lock(), mode) ==
-    rclcpp::FutureReturnCode::SUCCESS) {
+    rclcpp::FutureReturnCode::SUCCESS)
+  {
     auto result = mode.get();
     cache_[part_name].mode = result->current_mode;
   }

--- a/system_modes/src/system_modes/mode_observer.cpp
+++ b/system_modes/src/system_modes/mode_observer.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2018 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/microros/system_modes
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "system_modes/mode_observer.hpp"
+
+#include <lifecycle_msgs/msg/state.hpp>
+#include <lifecycle_msgs/msg/transition_event.hpp>
+
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "system_modes/msg/mode_event.hpp"
+
+using std::function;
+using std::map;
+using std::placeholders::_1;
+using std::string;
+using std::vector;
+
+using lifecycle_msgs::msg::State;
+using lifecycle_msgs::msg::Transition;
+using lifecycle_msgs::msg::TransitionEvent;
+using lifecycle_msgs::srv::GetState;
+
+using system_modes::msg::ModeEvent;
+using system_modes::srv::GetMode;
+
+using namespace std::chrono_literals;
+
+namespace system_modes
+{
+
+ModeObserver::ModeObserver(std::weak_ptr<rclcpp::Node> handle)
+: node_handle_(handle)
+{
+}
+
+StateAndMode
+ModeObserver::get(const std::string & part_name)
+{
+  try {
+    return cache_.at(part_name);
+  } catch(const std::exception& e) {
+    std::cerr << e.what() << '\n';
+    return StateAndMode();
+  }
+}
+
+void
+ModeObserver::observe(const std::string & part_name)
+{
+  cache_[part_name] = StateAndMode();
+
+  // Initial try to get current state via service request
+  std::string topic = part_name + "/get_state";
+  auto gsrequest = std::make_shared<GetState::Request>();
+  auto stateclient = node_handle_.lock()->create_client<GetState>(topic);
+  auto state = stateclient->async_send_request(gsrequest);
+  if (rclcpp::spin_until_future_complete(node_handle_.lock(), state) ==
+    rclcpp::FutureReturnCode::SUCCESS) {
+    auto result = state.get();
+    cache_[part_name].state = result->current_state.id;
+  }
+
+  // Initial try to get current mode via service request
+  topic = part_name + "/get_mode";
+  auto gmrequest = std::make_shared<GetMode::Request>();
+  auto modeclient = node_handle_.lock()->create_client<GetMode>(topic);
+  auto mode = modeclient->async_send_request(gmrequest);
+  if (rclcpp::spin_until_future_complete(node_handle_.lock(), mode) ==
+    rclcpp::FutureReturnCode::SUCCESS) {
+    auto result = mode.get();
+    cache_[part_name].mode = result->current_mode;
+  }
+
+  // Set up transition subscriber and mode event subscriber for continuous observation
+  topic = part_name + "/transition_event";
+  function<void(TransitionEvent::SharedPtr)> transition_cb =
+    bind(&ModeObserver::transition_callback, this, _1, part_name);
+  auto state_sub = node_handle_.lock()->create_subscription<TransitionEvent>(
+    topic,
+    rclcpp::SystemDefaultsQoS(),
+    transition_cb);
+  state_subs_.emplace(part_name, state_sub);
+  topic = part_name + "/mode_event";
+  function<void(ModeEvent::SharedPtr)> mode_cb =
+    bind(&ModeObserver::mode_event_callback, this, _1, part_name);
+  auto mode_sub = node_handle_.lock()->create_subscription<ModeEvent>(
+    topic,
+    rclcpp::SystemDefaultsQoS(),
+    mode_cb);
+  mode_subs_.emplace(part_name, mode_sub);
+}
+
+void
+ModeObserver::stop_observing(const std::string & part_name)
+{
+  cache_.erase(part_name);
+  state_subs_.erase(part_name);
+  mode_subs_.erase(part_name);
+}
+
+void
+ModeObserver::transition_callback(
+  const TransitionEvent::SharedPtr msg,
+  const string & part_name)
+{
+  cache_[part_name].state = msg->goal_state.id;
+}
+
+void
+ModeObserver::mode_event_callback(
+  const ModeEvent::SharedPtr msg,
+  const string & part_name)
+{
+  cache_[part_name].mode = msg->goal_mode.label;
+}
+
+}  // namespace system_modes

--- a/system_modes/test/launchtest/modes_observer.launch.py.in
+++ b/system_modes/test/launchtest/modes_observer.launch.py.in
@@ -1,0 +1,72 @@
+import os
+
+import unittest
+
+import ament_index_python
+import launch
+import launch_ros
+import launch_testing.actions
+import launch_testing_ros
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+
+def generate_test_description():
+    os.environ['OSPL_VERBOSITY'] = '8'
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+
+    modelfile = '@MODELFILE@'
+
+    modes_observer = ExecuteProcess(
+        cmd=[
+            "ros2",
+            "run",
+            "system_modes",
+            "modes_observer_test_node"],
+        name='modes_observer_test_node',
+        emulate_tty=True,
+        output='screen')
+
+    mode_manager = launch.actions.IncludeLaunchDescription(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
+            ament_index_python.packages.get_package_share_directory(
+                'system_modes') + '/launch/mode_manager.launch.py'),
+        launch_arguments={'modelfile': modelfile}.items())
+
+    test_nodes = ExecuteProcess(
+        cmd=[
+            "@PYTHON_EXECUTABLE@",
+            "@TEST_NODES@"
+            ],
+        name='test_nodes',
+        emulate_tty=True,
+        output='screen')
+
+    launch_description = LaunchDescription()
+    launch_description.add_action(modes_observer)
+    launch_description.add_action(mode_manager)
+    launch_description.add_action(test_nodes)
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+
+    return launch_description, locals()
+
+class TestModeManagement(unittest.TestCase):
+
+    def test_processes_output(self, proc_output, modes_observer):
+        """Check manager and nodes logging output for expected strings."""
+
+        from launch_testing.tools.output import get_default_filtered_prefixes
+        output_filter = launch_testing_ros.tools.basic_output_filter(
+            filtered_prefixes=get_default_filtered_prefixes() + ['service not available, waiting...'],
+            filtered_rmw_implementation='@RMW_IMPLEMENTATION@'
+        )
+        proc_output.assertWaitFor(
+            expected_output=launch_testing.tools.expected_output_from_file(path="@EXPECTED_OUTPUT@"),
+            process=modes_observer,
+            output_filter=output_filter,
+            timeout=15,
+            stream='stdout')
+
+        import time
+        time.sleep(1)

--- a/system_modes/test/launchtest/modes_observer.py
+++ b/system_modes/test/launchtest/modes_observer.py
@@ -1,0 +1,148 @@
+from time import sleep
+
+from lifecycle_msgs.msg import TransitionEvent
+from lifecycle_msgs.srv import ChangeState
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+
+from system_modes.msg import ModeEvent
+from system_modes.srv import ChangeMode
+
+
+class FakeLifecycleNode(Node):
+
+    def __init__(self, name):
+        super().__init__(name)
+
+        self.declare_parameter('foo')
+        self.declare_parameter('bar')
+
+        self.pubs = self.create_publisher(
+            TransitionEvent, self.get_name() + '/transition_event',
+            10)
+        self.pubm = self.create_publisher(ModeEvent, self.get_name() + '/mode_event', 10)
+
+        # State change service
+        self.srvs = self.create_service(
+            ChangeState,
+            self.get_name() + '/change_state',
+            self.change_state_callback)
+        self.add_on_set_parameters_callback(self.parameter_callback)
+
+    def change_state_callback(self, request, response):
+        response.success = True
+
+        msg = TransitionEvent()
+        if request.transition.id == 1 or request.transition.id == 4:
+            print("node ", self.get_name(), " pretending to go to 'inactive'")
+            msg.transition = request.transition
+            msg.goal_state.id = 2
+            msg.goal_state.label = 'inactive'
+        elif request.transition.id == 3:
+            print("node ", self.get_name(), " pretending to go to 'active'")
+            msg.transition = request.transition
+            msg.goal_state.id = 3
+            msg.goal_state.label = 'active'
+        self.pubs.publish(msg)
+
+        return response
+
+    def parameter_callback(self, params):
+        for p in params:
+            if p.name == 'foo' and p.type_ == Parameter.Type.DOUBLE:
+                msg = ModeEvent()
+                if p.value == 0.2:
+                    msg.goal_mode.label = 'EE'
+                elif p.value == 0.9:
+                    msg.goal_mode.label = 'FF'
+                else:
+                    # default mode
+                    msg.goal_mode.label = '__DEFAULT__'
+                self.pubm.publish(msg)
+        self.successful = True
+        return self
+
+
+class LifecycleClient(Node):
+
+    ready = False
+
+    def __init__(self):
+        super().__init__('system_modes_test_client')
+
+        self.clis = self.create_client(ChangeState, '/sys/change_state')
+        while not self.clis.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('service not available, waiting again...')
+        self.reqs = ChangeState.Request()
+
+        self.clim = self.create_client(ChangeMode, '/sys/change_mode')
+        while not self.clim.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('service not available, waiting again...')
+        self.reqm = ChangeMode.Request()
+
+        self.ready = True
+
+    def configure_system(self):
+        while not self.ready:
+            sleep(.2)
+        self.reqs.transition.id = 1
+        self.reqs.transition.label = 'configure'
+        self.future = self.clis.call_async(self.reqs)
+
+    def activate_system(self):
+        self.reqs.transition.id = 3
+        self.reqs.transition.label = 'activate'
+        self.future = self.clis.call_async(self.reqs)
+
+    def change_mode(self, mode):
+        self.reqm.mode_name = mode
+        self.future = self.clim.call_async(self.reqm)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    try:
+        executor = SingleThreadedExecutor()
+        node_a = FakeLifecycleNode('A')
+        node_b = FakeLifecycleNode('B')
+
+        executor.add_node(node_a)
+        executor.add_node(node_b)
+
+        lc = LifecycleClient()
+
+        try:
+            lc.configure_system()
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+
+            lc.activate_system()
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+
+            lc.change_mode('CC')
+
+            executor.spin()
+        finally:
+            executor.shutdown()
+            node_a.destroy_node()
+            node_b.destroy_node()
+    finally:
+        rclpy.shutdown()
+        return 0
+
+
+if __name__ == '__main__':
+    main()

--- a/system_modes/test/launchtest/modes_observer.py
+++ b/system_modes/test/launchtest/modes_observer.py
@@ -36,12 +36,12 @@ class FakeLifecycleNode(Node):
 
         msg = TransitionEvent()
         if request.transition.id == 1 or request.transition.id == 4:
-            print("node ", self.get_name(), " pretending to go to 'inactive'")
+            print('node ', self.get_name(), ' pretending to go to "inactive"')
             msg.transition = request.transition
             msg.goal_state.id = 2
             msg.goal_state.label = 'inactive'
         elif request.transition.id == 3:
-            print("node ", self.get_name(), " pretending to go to 'active'")
+            print('node ', self.get_name(), ' pretending to go to "active"')
             msg.transition = request.transition
             msg.goal_state.id = 3
             msg.goal_state.label = 'active'

--- a/system_modes/test/launchtest/modes_observer_expected_output.regex
+++ b/system_modes/test/launchtest/modes_observer_expected_output.regex
@@ -1,0 +1,7 @@
+cached:.*:inactive
+cached:sys:active.__DEFAULT__
+cached:A:inactive
+cached:B:active.__DEFAULT__
+cached:sys:active.CC
+cached:A:active.BB
+cached:B:active.FF

--- a/system_modes/test/launchtest/modes_observer_modes.yaml
+++ b/system_modes/test/launchtest/modes_observer_modes.yaml
@@ -1,0 +1,50 @@
+# system modes example
+---
+
+sys:
+  ros__parameters:
+    type: system
+    parts:
+      A
+      B
+    modes:
+      __DEFAULT__:
+        A: inactive
+        B: active
+      DD:
+        A: active.AA
+        B: active.EE
+      CC:
+        A: active.BB
+        B: active.FF
+
+A:
+  ros__parameters:
+    type: node
+    modes:
+      __DEFAULT__:
+        ros__parameters:
+          foo: 0.1
+      AA:
+        ros__parameters:
+          foo: 0.1
+      BB:
+        ros__parameters:
+          foo: 0.2
+
+B:
+  ros__parameters:
+    type: node
+    modes:
+      __DEFAULT__:
+        ros__parameters:
+          foo: 0.1
+          bar: ONE
+      EE:
+        ros__parameters:
+          foo: 0.2
+          bar: TWO
+      FF:
+        ros__parameters:
+          foo: 0.9
+          bar: THREE

--- a/system_modes/test/launchtest/modes_observer_test_node.cpp
+++ b/system_modes/test/launchtest/modes_observer_test_node.cpp
@@ -18,6 +18,7 @@
 #include <lifecycle_msgs/msg/state.hpp>
 #include <lifecycle_msgs/msg/transition_event.hpp>
 
+#include <cassert>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -70,6 +71,10 @@ public:
         std::cout << "cached:A:" << observer->get("A").as_string() << std::endl;
         std::cout << "cached:B:" << observer->get("B").as_string() << std::endl;
       });
+
+    auto sm = observer->get("foo");
+    assert(sm.state == 0);
+    assert(sm.mode.compare("") == 0);
   }
 
 private:

--- a/system_modes/test/launchtest/modes_observer_test_node.cpp
+++ b/system_modes/test/launchtest/modes_observer_test_node.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2018 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/microros/system_modes
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <rclcpp/rclcpp.hpp>
+#include <rcl_interfaces/msg/parameter_event.hpp>
+#include <rcl_interfaces/msg/parameter_type.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <lifecycle_msgs/msg/transition_event.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <utility>
+#include <iostream>
+
+#include "system_modes/mode_observer.hpp"
+
+using std::cerr;
+using std::cout;
+using std::string;
+using std::vector;
+using std::function;
+using std::make_pair;
+using std::shared_ptr;
+
+using system_modes::ModeObserver;
+using system_modes::DEFAULT_MODE;
+using system_modes::StateAndMode;
+using system_modes::msg::ModeEvent;
+
+using lifecycle_msgs::msg::State;
+using lifecycle_msgs::msg::TransitionEvent;
+
+using rcl_interfaces::msg::ParameterType;
+using rcl_interfaces::msg::ParameterEvent;
+
+using namespace std::chrono_literals;
+
+class ModeObserverNode : public rclcpp::Node
+{
+public:
+  ModeObserverNode()
+  : Node("testobservernode")
+  {
+  }
+  void start_observing()
+  {
+    observer = std::make_shared<ModeObserver>(shared_from_this());
+    observer->observe("sys");
+    observer->observe("A");
+    observer->observe("B");
+
+    periodic_timer = this->create_wall_timer(
+      500ms,
+      [this]() {
+        std::cout << "cached:sys:" << observer->get("sys").as_string() << std::endl;
+        std::cout << "cached:A:" << observer->get("A").as_string() << std::endl;
+        std::cout << "cached:B:" << observer->get("B").as_string() << std::endl;
+      });
+  }
+
+private:
+  std::shared_ptr<ModeObserver> observer;
+  rclcpp::TimerBase::SharedPtr periodic_timer;
+};
+
+int main(int argc, char * argv[])
+{
+  using namespace std::placeholders;
+
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+  rclcpp::init(argc, argv);
+
+  auto observer = std::make_shared<ModeObserverNode>();
+  observer->start_observing();
+
+  rclcpp::executors::SingleThreadedExecutor exe;
+  exe.add_node(observer);
+  exe.spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/system_modes/test/test_mode_observer.cpp
+++ b/system_modes/test/test_mode_observer.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository https://github.com/microros/system_modes
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "system_modes/modefiles.h"
+#include "system_modes/mode_observer.hpp"
+
+using system_modes::ModeObserver;
+using system_modes::StateAndMode;
+
+class TestModeObserver : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    rclcpp::executors::SingleThreadedExecutor exe;
+    my_node = std::make_shared<rclcpp::Node>("testobserver");
+    observer = new ModeObserver(my_node);
+  }
+
+  void TearDown()
+  {
+    delete observer;
+  }
+
+  ModeObserver * observer;
+  std::shared_ptr<rclcpp::Node> my_node;
+};
+
+TEST_F(TestModeObserver, initialization) {
+  auto my_node = std::make_shared<rclcpp::Node>("testobserver");
+
+  ModeObserver * my_observer;
+  EXPECT_NO_THROW(my_observer = new ModeObserver(my_node));
+
+  (void) my_observer;
+}
+
+TEST_F(TestModeObserver, start_stop_observing) {
+  EXPECT_NO_THROW(observer->observe("foo"));
+
+  EXPECT_NO_THROW(observer->stop_observing("foo"));
+  EXPECT_NO_THROW(observer->stop_observing("bar"));
+}
+
+TEST_F(TestModeObserver, observing) {
+  EXPECT_NO_THROW(observer->observe("foo"));
+
+  StateAndMode sm;
+  EXPECT_NO_THROW(sm = observer->get("foo"));
+  EXPECT_EQ(0u, sm.state);
+  EXPECT_STREQ("", sm.mode.c_str());
+}

--- a/system_modes/test/test_state_and_mode_struct.cpp
+++ b/system_modes/test/test_state_and_mode_struct.cpp
@@ -32,6 +32,8 @@ class TestStateAndMode : public ::testing::Test
 protected:
   void SetUp()
   {
+    unknown.state = State::PRIMARY_STATE_UNKNOWN;
+
     inactive.state = State::PRIMARY_STATE_INACTIVE;
 
     active.state = State::PRIMARY_STATE_ACTIVE;
@@ -47,8 +49,15 @@ protected:
   {
   }
 
-  StateAndMode inactive, active, active_default, active_foo;
+  StateAndMode unknown, inactive, active, active_default, active_foo;
 };
+
+TEST_F(TestStateAndMode, initialization_as_unknown) {
+  {
+    StateAndMode initial;
+    EXPECT_EQ(unknown, initial);
+  }
+}
 
 TEST_F(TestStateAndMode, comparison) {
   {

--- a/system_modes/test/test_state_and_mode_struct.cpp
+++ b/system_modes/test/test_state_and_mode_struct.cpp
@@ -112,3 +112,13 @@ TEST_F(TestStateAndMode, string_setter) {
     EXPECT_EQ(inactive, copy);
   }
 }
+
+TEST_F(TestStateAndMode, string_unknown) {
+  {
+    EXPECT_FALSE(inactive.unknown());
+    EXPECT_FALSE(active.unknown());
+    EXPECT_FALSE(active_default.unknown());
+    EXPECT_FALSE(active_foo.unknown());
+    EXPECT_TRUE(unknown.unknown());
+  }
+}


### PR DESCRIPTION
Introduces a modes observer class that

- can be configured to monitor an arbitrary number of nodes and systems for their states and modes. To do so it
  - initially queries the getState and getMode services of monitored entities
  - after that continuously monitors ../transition_event and ../mode_event topics of monitored entities
- caches the states+modes of monitored entities locally for fast local access

The mode observer is supposed to be instantiated by+inside a ROS 2 node.

https://github.com/micro-ROS/system_modes/issues/66