### PR TITLE
Fixing flaky tests

### DIFF
--- a/system_modes/test/launchtest/manager_and_monitor.py
+++ b/system_modes/test/launchtest/manager_and_monitor.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from lifecycle_msgs.srv import ChangeState
 from rcl_interfaces.msg import SetParametersResult
 
@@ -85,19 +87,15 @@ def main(args=None):
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.change_mode('CC')
-
             executor.spin()
         finally:
             executor.shutdown()

--- a/system_modes/test/launchtest/modes_observer.launch.py.in
+++ b/system_modes/test/launchtest/modes_observer.launch.py.in
@@ -18,15 +18,11 @@ def generate_test_description():
 
     modelfile = '@MODELFILE@'
 
-    modes_observer = ExecuteProcess(
-        cmd=[
-            "ros2",
-            "run",
-            "system_modes",
-            "modes_observer_test_node"],
-        name='modes_observer_test_node',
-        emulate_tty=True,
-        output='screen')
+    modes_observer = launch_ros.actions.Node(
+            package='system_modes',
+            executable='modes_observer_test_node',
+            emulate_tty=True,
+            output='screen')
 
     mode_manager = launch.actions.IncludeLaunchDescription(
         launch.launch_description_sources.PythonLaunchDescriptionSource(
@@ -39,9 +35,7 @@ def generate_test_description():
             "@PYTHON_EXECUTABLE@",
             "@TEST_NODES@"
             ],
-        name='test_nodes',
-        emulate_tty=True,
-        output='screen')
+        name='test_nodes',)
 
     launch_description = LaunchDescription()
     launch_description.add_action(modes_observer)

--- a/system_modes/test/launchtest/modes_observer.py
+++ b/system_modes/test/launchtest/modes_observer.py
@@ -117,21 +117,14 @@ def main(args=None):
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
 
+            sleep(1)
             lc.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
 
+            sleep(1)
             lc.change_mode('CC')
 
             executor.spin()

--- a/system_modes/test/launchtest/modes_observer.py
+++ b/system_modes/test/launchtest/modes_observer.py
@@ -117,16 +117,15 @@ def main(args=None):
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
-            sleep(1)
             lc.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
-            sleep(1)
             lc.change_mode('CC')
-
             executor.spin()
         finally:
             executor.shutdown()

--- a/system_modes/test/launchtest/redundant_mode_changes.py
+++ b/system_modes/test/launchtest/redundant_mode_changes.py
@@ -1,7 +1,10 @@
+from time import sleep
+
 from lifecycle_msgs.srv import ChangeState
 from rcl_interfaces.msg import SetParametersResult
 
 import rclpy
+
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.parameter import Parameter
@@ -102,33 +105,28 @@ def main(args=None):
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)
 
             lc.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.change_A_mode('AA')
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            lc.change_A_mode('AA')  # redundant, should be ignored
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            lc.change_A_mode('BB')
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(3)  # give the system some time to converge
 
+            lc.change_A_mode('AA')  # this is the tested aspect: call redundant, should be ignored
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
+
+            lc.change_A_mode('BB')
             executor.spin()
         finally:
             executor.shutdown()

--- a/system_modes/test/launchtest/redundant_mode_changes_expected_output.regex
+++ b/system_modes/test/launchtest/redundant_mode_changes_expected_output.regex
@@ -1,4 +1,3 @@
-Transition [AB]:configure
-Transition [AB]:activate
+Transition [AB]
 Parameter callback #0 A:foo:0.2
 Parameter callback #1 A:foo:0.3

--- a/system_modes/test/launchtest/two_independent_hierarchies.py
+++ b/system_modes/test/launchtest/two_independent_hierarchies.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from lifecycle_msgs.srv import ChangeState
 from rcl_interfaces.msg import SetParametersResult
 
@@ -89,27 +91,26 @@ def main(args=None):
         try:
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
             lc2.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.activate_system()
+            executor.spin_once(timeout_sec=1)
+            executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             lc2.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.change_mode('CC')
             executor.spin_once(timeout_sec=1)
-            lc2.change_mode('DD')
             executor.spin_once(timeout_sec=1)
-
+            lc2.change_mode('DD')
             executor.spin()
         finally:
             executor.shutdown()

--- a/system_modes/test/launchtest/two_lifecycle_nodes.py
+++ b/system_modes/test/launchtest/two_lifecycle_nodes.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from lifecycle_msgs.srv import ChangeState
 from rcl_interfaces.msg import SetParametersResult
 
@@ -85,19 +87,15 @@ def main(args=None):
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.change_mode('CC')
-
             executor.spin()
         finally:
             executor.shutdown()

--- a/system_modes/test/launchtest/two_mixed_nodes.py
+++ b/system_modes/test/launchtest/two_mixed_nodes.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from lifecycle_msgs.srv import ChangeState
 from rcl_interfaces.msg import SetParametersResult
 
@@ -103,19 +105,15 @@ def main(args=None):
             lc.configure_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.activate_system()
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
             executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
-            executor.spin_once(timeout_sec=1)
+            sleep(2)  # give the system some time to converge
 
             lc.change_mode('CC')
-
             executor.spin()
         finally:
             executor.shutdown()


### PR DESCRIPTION
* Fix flaky launch tests
* Fix that processes sometimes don't react to `SIGINT` properly, leaving ugly error messages in the test procedure (not failing the testsm though)

https://github.com/micro-ROS/system_modes/issues/70