### PR TITLE
More flexibility in specifying the default mode

### DIFF
--- a/system_modes/README.md
+++ b/system_modes/README.md
@@ -40,7 +40,7 @@ System modes extend the *ACTIVE* state of the ROS 2 lifecycle and allow to speci
 * **Modes of nodes** consist of parameter values.
 * **Modes of (sub-)system)** consist of modes of their *parts*.
 
-For example, a node representing an actuator might provide different modes that specify certain maximum speed or maximum torque values. An actuation sub-system, grouping several actuator nodes, might provide modes that activate/deactivate certain contained actuator nodes and/or change their modes based on its own modes.
+For example, a node representing an actuator might provide different modes that specify certain maximum speed or maximum torque values. An actuation sub-system, grouping several actuator nodes, might provide modes that activate/deactivate certain contained actuator nodes and/or change their modes based on its own modes. Each part (system or node) has to specify a default mode that is selected, if no specific mode is requested.
 
 Both, the [system hierarchy](#hierarchical-system-modeling) as well as the system modes are specified in a system modes and hierarchy model file (SHM file, yaml format) that can be parsed by the [mode inference](#mode-inference) mechanism. The SMH file adheres to the following format *(curly brackets indicate placeholders, square brackets indicate optional parts, ellipses indicate repeatability)*:
 
@@ -48,13 +48,11 @@ Both, the [system hierarchy](#hierarchical-system-modeling) as well as the syste
 {system}:
   ros__parameters:
     type: system
+    defaultmode: {MODE}
     parts:
-      {node}
+      {node or system}
       […]
     modes:
-      __DEFAULT__:
-        {node}: {state}[.{MODE}]
-        […]
       {MODE}:
         {node}: {state}[.{MODE}]
         […]
@@ -64,11 +62,8 @@ Both, the [system hierarchy](#hierarchical-system-modeling) as well as the syste
 {node}:
   ros__parameters:
     type: node
+    defaultmode: {MODE}
     modes:
-      __DEFAULT__:
-        ros__parameters:
-          {parameter}: {value}
-          […]
       {MODE}:
         ros__parameters:
           {parameter}: {value}

--- a/system_modes/include/system_modes/mode.hpp
+++ b/system_modes/include/system_modes/mode.hpp
@@ -74,8 +74,7 @@ protected:
 class DefaultMode : public ModeBase
 {
 public:
-  DefaultMode();
-  explicit DefaultMode(const std::string & mode_name) = delete;
+  explicit DefaultMode(const std::string & mode_name = DEFAULT_MODE);
   // cppcheck-suppress unknownMacro
   RCLCPP_DISABLE_COPY(DefaultMode)
 

--- a/system_modes/include/system_modes/mode.hpp
+++ b/system_modes/include/system_modes/mode.hpp
@@ -65,6 +65,10 @@ public:
   virtual const std::vector<std::string> get_parts() const;
   virtual const StateAndMode get_part_mode(const std::string & part) const;
 
+  /**
+   * Created StateAndMode struct that describes this mode
+   */
+  virtual const StateAndMode sm() const;
   virtual std::string print() const;
 
 protected:

--- a/system_modes/include/system_modes/mode_impl.hpp
+++ b/system_modes/include/system_modes/mode_impl.hpp
@@ -61,9 +61,7 @@ struct StateAndMode
       return true;
     }
 
-    return cmp.mode.compare(mode) == 0 ||                            // same mode
-           (cmp.mode.compare(DEFAULT_MODE) == 0 && mode.empty()) ||  // we consider empty and
-           (mode.compare(DEFAULT_MODE) == 0 && cmp.mode.empty());    // DEFAULT_MODE the same
+    return cmp.mode.compare(mode) == 0;
   }
 
   bool operator!=(const StateAndMode & cmp) const

--- a/system_modes/include/system_modes/mode_inference.hpp
+++ b/system_modes/include/system_modes/mode_inference.hpp
@@ -62,6 +62,11 @@ public:
   virtual StateAndMode infer_node(const std::string & part);
   virtual StateAndMode infer_system(const std::string & part);
 
+  virtual bool matching_modes(
+    const std::string & part,
+    const StateAndMode & a,
+    const StateAndMode & b) const;
+
   /**
    * Infers latest transitions of systems
    *
@@ -75,12 +80,15 @@ public:
 
   virtual StateAndMode get_target(const std::string & part) const;
   virtual ModeConstPtr get_mode(const std::string & part, const std::string & mode) const;
+  virtual ModeConstPtr get_default_mode(const std::string & part) const;
+  virtual const std::string get_default_mode_name(const std::string & part) const;
   virtual std::vector<std::string> get_available_modes(const std::string & part) const;
 
   virtual ~ModeInference() = default;
 
 protected:
   virtual bool matching_parameters(const rclcpp::Parameter &, const rclcpp::Parameter &) const;
+
   virtual void read_modes_from_model(const std::string & model_path);
   virtual void add_param_to_mode(ModeBasePtr, const rclcpp::Parameter &);
 
@@ -88,12 +96,13 @@ private:
   StatesMap nodes_, nodes_target_, nodes_cache_;
   StatesMap systems_, systems_target_, systems_cache_;
   std::map<std::string, ModeMap> modes_;
+  std::map<std::string, std::string> default_modes_;
   ParametersMap parameters_;
 
   mutable std::shared_timed_mutex
     nodes_mutex_, systems_mutex_,
-    modes_mutex_, parts_mutex_,
-    param_mutex_;
+    modes_mutex_, default_modes_mutex_,
+    parts_mutex_, param_mutex_;
   mutable std::shared_timed_mutex
     nodes_target_mutex_, systems_target_mutex_;
   mutable std::shared_timed_mutex

--- a/system_modes/include/system_modes/mode_inference.hpp
+++ b/system_modes/include/system_modes/mode_inference.hpp
@@ -85,8 +85,6 @@ protected:
   virtual void add_param_to_mode(ModeBasePtr, const rclcpp::Parameter &);
 
 private:
-  ModeHandling * mode_handling_;
-
   StatesMap nodes_, nodes_target_, nodes_cache_;
   StatesMap systems_, systems_target_, systems_cache_;
   std::map<std::string, ModeMap> modes_;

--- a/system_modes/src/mode_manager_node.cpp
+++ b/system_modes/src/mode_manager_node.cpp
@@ -28,8 +28,6 @@
 
 #include "system_modes/mode_manager.hpp"
 
-using std::cerr;
-using std::cout;
 using std::string;
 using std::vector;
 using std::function;
@@ -37,7 +35,6 @@ using std::make_pair;
 using std::shared_ptr;
 
 using system_modes::ModeManager;
-using system_modes::DEFAULT_MODE;
 using system_modes::StateAndMode;
 using system_modes_msgs::msg::ModeEvent;
 
@@ -77,7 +74,7 @@ void transition_request_callback(
   } else {
     manager->inference()->update_target(
       node_name,
-      StateAndMode(msg->goal_state.id, DEFAULT_MODE));
+      StateAndMode(msg->goal_state.id, manager->inference()->get_default_mode_name(node_name)));
   }
 }
 

--- a/system_modes/src/mode_monitor_node.cpp
+++ b/system_modes/src/mode_monitor_node.cpp
@@ -28,9 +28,6 @@
 
 #include "system_modes/mode_monitor.hpp"
 
-using std::cerr;
-using std::cout;
-using std::endl;
 using std::string;
 using std::vector;
 using std::function;
@@ -41,7 +38,6 @@ using std::make_shared;
 using std::invalid_argument;
 
 using system_modes::ModeMonitor;
-using system_modes::DEFAULT_MODE;
 using system_modes::StateAndMode;
 using system_modes_msgs::msg::ModeEvent;
 using lifecycle_msgs::msg::State;
@@ -78,7 +74,7 @@ void transition_request_callback(
   } else {
     monitor->inference()->update_target(
       node_name,
-      StateAndMode(msg->goal_state.id, DEFAULT_MODE));
+      StateAndMode(msg->goal_state.id, monitor->inference()->get_default_mode_name(node_name)));
   }
 }
 

--- a/system_modes/src/system_modes/mode.cpp
+++ b/system_modes/src/system_modes/mode.cpp
@@ -108,10 +108,7 @@ ModeBase::print() const
 const StateAndMode
 ModeBase::sm() const
 {
-  StateAndMode sm;
-  sm.state = State::PRIMARY_STATE_ACTIVE;
-  sm.mode = this->get_name();
-  return sm;
+  return StateAndMode(State::PRIMARY_STATE_ACTIVE, this->get_name());
 }
 
 DefaultMode::DefaultMode(const std::string & mode_name)

--- a/system_modes/src/system_modes/mode.cpp
+++ b/system_modes/src/system_modes/mode.cpp
@@ -105,6 +105,15 @@ ModeBase::print() const
   return os.str();
 }
 
+const StateAndMode
+ModeBase::sm() const
+{
+  StateAndMode sm;
+  sm.state = State::PRIMARY_STATE_ACTIVE;
+  sm.mode = this->get_name();
+  return sm;
+}
+
 DefaultMode::DefaultMode(const std::string & mode_name)
 : ModeBase(mode_name)
 {
@@ -128,7 +137,7 @@ DefaultMode::set_part_mode(
   const StateAndMode stateAndMode)
 {
   if (stateAndMode.mode.empty()) {
-    this->mode_impl_.add_part_mode(part, StateAndMode(stateAndMode.state, DEFAULT_MODE));
+    this->mode_impl_.add_part_mode(part, StateAndMode(stateAndMode.state, ""));
   } else {
     this->mode_impl_.add_part_mode(part, stateAndMode);
   }
@@ -170,7 +179,7 @@ Mode::set_part_mode(
   const StateAndMode stateAndMode)
 {
   if (stateAndMode.mode.empty()) {
-    this->mode_impl_.add_part_mode(part, StateAndMode(stateAndMode.state, DEFAULT_MODE));
+    this->mode_impl_.add_part_mode(part, StateAndMode(stateAndMode.state, ""));
   } else {
     this->mode_impl_.add_part_mode(part, stateAndMode);
   }

--- a/system_modes/src/system_modes/mode.cpp
+++ b/system_modes/src/system_modes/mode.cpp
@@ -105,8 +105,8 @@ ModeBase::print() const
   return os.str();
 }
 
-DefaultMode::DefaultMode()
-: ModeBase(DEFAULT_MODE)
+DefaultMode::DefaultMode(const std::string & mode_name)
+: ModeBase(mode_name)
 {
 }
 

--- a/system_modes/src/system_modes/mode_inference.cpp
+++ b/system_modes/src/system_modes/mode_inference.cpp
@@ -42,8 +42,7 @@ namespace system_modes
 {
 
 ModeInference::ModeInference(const string & model_path)
-: mode_handling_(new ModeHandling(model_path)),
-  nodes_(), nodes_target_(),
+: nodes_(), nodes_target_(),
   systems_(), systems_target_(),
   modes_(),
   nodes_mutex_(), systems_mutex_(), modes_mutex_(), parts_mutex_(),

--- a/system_modes/src/system_modes/mode_inference.cpp
+++ b/system_modes/src/system_modes/mode_inference.cpp
@@ -778,7 +778,8 @@ ModeInference::matching_parameters(const Parameter & target, const Parameter & a
 }
 
 bool
-ModeInference::matching_modes(const std::string & part,
+ModeInference::matching_modes(
+  const std::string & part,
   const StateAndMode & a,
   const StateAndMode & b) const
 {

--- a/system_modes/src/system_modes/mode_inference.cpp
+++ b/system_modes/src/system_modes/mode_inference.cpp
@@ -528,11 +528,6 @@ ModeInference::read_modes_from_model(const string & model_path)
           continue;
         }
 
-        // Take the first one as backup
-        if (default_mode_name.empty()) {
-          default_mode_name = mode_name;
-        }
-
         /**
          * Check for mode with name '__DEFAULT__'
          *
@@ -541,7 +536,7 @@ ModeInference::read_modes_from_model(const string & model_path)
          */
         if (mode_name.compare(DEFAULT_MODE) == 0) {
           default_mode_name = DEFAULT_MODE;
-          std::cout << "WARNING: Specifying the default mode just by its name '__DEFAULT__'" <<
+          std::cerr << "WARNING: Specifying the default mode just by its name '__DEFAULT__'" <<
             " is deprecated. Please specify the 'defaultmode' parameter for '" <<
             part_name << "' instead." << std::endl;
           break;

--- a/system_modes/src/system_modes/mode_manager.cpp
+++ b/system_modes/src/system_modes/mode_manager.cpp
@@ -405,8 +405,8 @@ ModeManager::change_state(
       this->change_part_state(part, transition_id);
     }
   } else {
-    RCLCPP_DEBUG(this->get_logger(), "  active, so trigger mode transition to __DEFAULT__");
-    this->change_mode(node_name, DEFAULT_MODE);
+    RCLCPP_DEBUG(this->get_logger(), "  active, so trigger mode transition to default");
+    this->change_mode(node_name, mode_inference_->get_default_mode_name(node_name));
   }
   return true;
 }
@@ -481,7 +481,7 @@ ModeManager::change_mode(
         // state/transition and mode via mode inference
         this->change_part_state(part, Transition::TRANSITION_ACTIVATE);
         if (stateAndMode.mode.empty()) {
-          this->change_part_mode(part, DEFAULT_MODE);
+          this->change_part_mode(part, mode_inference_->get_default_mode_name(part));
         } else {
           this->change_part_mode(part, stateAndMode.mode);
         }
@@ -530,13 +530,19 @@ ModeManager::change_part_state(const string & node, unsigned int transition)
 }
 
 void
-ModeManager::change_part_mode(const string & node, const string & mode)
+ModeManager::change_part_mode(const string & node, const string & m)
 {
   RCLCPP_DEBUG(
     this->get_logger(),
-    " changing mode of part %s to %s",
+    " changing mode of part %s to mode '%s'",
     node.c_str(),
-    mode.c_str());
+    m.c_str());
+
+  // We consider empty mode = default mode
+  auto mode = m;
+  if (mode.empty()) {
+    mode = mode_inference_->get_default_mode_name(node);
+  }
 
   auto request = std::make_shared<ChangeMode::Request>();
   request->mode_name = mode;

--- a/system_modes/test/launchtest/modes_observer_test_node.cpp
+++ b/system_modes/test/launchtest/modes_observer_test_node.cpp
@@ -29,7 +29,6 @@
 
 #include "system_modes/mode_observer.hpp"
 
-using std::cerr;
 using std::cout;
 using std::string;
 using std::vector;
@@ -38,7 +37,6 @@ using std::make_pair;
 using std::shared_ptr;
 
 using system_modes::ModeObserver;
-using system_modes::DEFAULT_MODE;
 using system_modes::StateAndMode;
 using system_modes_msgs::msg::ModeEvent;
 

--- a/system_modes/test/launchtest/two_mixed_nodes_modes.yaml
+++ b/system_modes/test/launchtest/two_mixed_nodes_modes.yaml
@@ -21,8 +21,9 @@ sys:
 A:
   ros__parameters:
     type: node
+    defaultmode: DEFAULT
     modes:
-      __DEFAULT__:
+      DEFAULT:
         ros__parameters:
           foo: 0.1
       AA:
@@ -35,11 +36,8 @@ A:
 B:
   ros__parameters:
     type: node
+    defaultmode: DEFAULT
     modes:
-      __DEFAULT__:
-        ros__parameters:
-          foo: 0.1
-          bar: ONE
       EE:
         ros__parameters:
           foo: 0.2
@@ -48,3 +46,7 @@ B:
         ros__parameters:
           foo: 0.9
           bar: THREE
+      DEFAULT:
+        ros__parameters:
+          foo: 0.1
+          bar: ONE

--- a/system_modes/test/test_default_mode.cpp
+++ b/system_modes/test/test_default_mode.cpp
@@ -40,7 +40,7 @@ protected:
 
   void SetUp()
   {
-    default_mode = DefaultModePtr(new DefaultMode());
+    default_mode = DefaultModePtr(new DefaultMode("custom name"));
   }
 
   void TearDown()
@@ -57,6 +57,9 @@ TEST_F(TestDefaultMode, construction_and_destruction) {
   {
     DefaultMode mode;
     EXPECT_EQ("__DEFAULT__", mode.get_name());
+
+    DefaultMode mode_named("custom default mode name");
+    EXPECT_EQ("custom default mode name", mode_named.get_name());
   }
 }
 

--- a/system_modes/test/test_mode_handling.cpp
+++ b/system_modes/test/test_mode_handling.cpp
@@ -72,6 +72,8 @@ TEST(TestModeFilesParse, parse_rules) {
 TEST(TestModeFilesParse, test_rules) {
   ModeHandling * handling = new ModeHandling(MODE_FILE_RULES);
 
+  StateAndMode active_default(State::PRIMARY_STATE_ACTIVE, "DEFAULT");
+
   auto rules = handling->get_rules_for("system", StateAndMode(State::PRIMARY_STATE_ACTIVE, "AA"));
 
   EXPECT_EQ("degrade_from_AA", rules[0].name);
@@ -79,7 +81,7 @@ TEST(TestModeFilesParse, test_rules) {
   EXPECT_EQ(StateAndMode(State::PRIMARY_STATE_ACTIVE, "AA"), rules[0].system_target);
   EXPECT_EQ("part0", rules[0].part);
   EXPECT_EQ(StateAndMode(State::PRIMARY_STATE_INACTIVE), rules[0].part_actual);
-  EXPECT_EQ(StateAndMode(State::PRIMARY_STATE_ACTIVE), rules[0].new_system_target);
+  EXPECT_EQ(active_default, rules[0].new_system_target);
 
   EXPECT_EQ("inactive_from_AA", rules[1].name);
   EXPECT_EQ("system", rules[1].system);
@@ -95,7 +97,7 @@ TEST(TestModeFilesParse, test_rules) {
   EXPECT_EQ(StateAndMode(State::PRIMARY_STATE_ACTIVE, "BB"), rules[0].system_target);
   EXPECT_EQ("part0", rules[0].part);
   EXPECT_EQ(StateAndMode(State::PRIMARY_STATE_INACTIVE), rules[0].part_actual);
-  EXPECT_EQ(StateAndMode(State::PRIMARY_STATE_ACTIVE), rules[0].new_system_target);
+  EXPECT_EQ(active_default, rules[0].new_system_target);
 
   EXPECT_EQ("inactive_from_BB", rules[1].name);
   EXPECT_EQ("system", rules[1].system);

--- a/system_modes/test/test_modes.yaml
+++ b/system_modes/test/test_modes.yaml
@@ -4,11 +4,12 @@
 system:
   ros__parameters:
     type: system
+    defaultmode: DEFAULT
     parts:
       part0
       part1
     modes:
-      __DEFAULT__:
+      DEFAULT:
         part0: inactive
         part1: active
       AA:
@@ -38,11 +39,8 @@ part0:
 part1:
   ros__parameters:
     type: node
+    defaultmode: NORMAL
     modes:
-      __DEFAULT__:
-        ros__parameters:
-          foo: 0.1
-          bar: WARN
       AAA:
         ros__parameters:
           foo: 0.2
@@ -51,4 +49,8 @@ part1:
         ros__parameters:
           foo: 0.9
           bar: ERR
+      NORMAL:
+        ros__parameters:
+          foo: 0.1
+          bar: WARN
 

--- a/system_modes/test/test_modes_rules.yaml
+++ b/system_modes/test/test_modes_rules.yaml
@@ -4,11 +4,12 @@
 system:
   ros__parameters:
     type: system
+    defaultmode: DEFAULT
     parts:
       part0
       part1
     modes:
-      __DEFAULT__:
+      DEFAULT:
         part0: inactive
         part1: active
       AA:
@@ -21,11 +22,11 @@ system:
       degrade_from_AA:
         if_target: active.AA
         if_part: [part0, inactive]
-        new_target: active.__DEFAULT__
+        new_target: active.DEFAULT
       degrade_from_BB:
         if_target: active.BB
         if_part: [part0, inactive]
-        new_target: active.__DEFAULT__
+        new_target: active.DEFAULT
       inactive_from_AA:
         if_target: active.AA
         if_part: [part1, inactive]
@@ -55,8 +56,9 @@ part0:
 part1:
   ros__parameters:
     type: node
+    defaultmode: DEFAULT
     modes:
-      __DEFAULT__:
+      DEFAULT:
         ros__parameters:
           foo: 0.1
           bar: WARN

--- a/system_modes/test/test_state_and_mode_struct.cpp
+++ b/system_modes/test/test_state_and_mode_struct.cpp
@@ -39,7 +39,7 @@ protected:
     active.state = State::PRIMARY_STATE_ACTIVE;
 
     active_default.state = State::PRIMARY_STATE_ACTIVE;
-    active_default.mode = "__DEFAULT__";
+    active_default.mode = "DEFAULT";
 
     active_foo.state = State::PRIMARY_STATE_ACTIVE;
     active_foo.mode = "FOO";
@@ -63,7 +63,6 @@ TEST_F(TestStateAndMode, comparison) {
   {
     EXPECT_EQ(inactive, inactive);
     EXPECT_EQ(active, active);
-    EXPECT_EQ(active, active_default);
 
     EXPECT_NE(active, inactive);
     EXPECT_NE(active, active_foo);
@@ -79,7 +78,7 @@ TEST_F(TestStateAndMode, string_getter) {
   {
     EXPECT_EQ("inactive"s, inactive.as_string());
     EXPECT_EQ("active"s, active.as_string());
-    EXPECT_EQ("active.__DEFAULT__"s, active_default.as_string());
+    EXPECT_EQ("active.DEFAULT"s, active_default.as_string());
     EXPECT_EQ("active.FOO"s, active_foo.as_string());
     active_foo.state = State::PRIMARY_STATE_INACTIVE;
     EXPECT_EQ("inactive"s, active_foo.as_string());
@@ -93,7 +92,7 @@ TEST_F(TestStateAndMode, string_setter) {
     copy.from_string("active");
     EXPECT_EQ(active, copy);
 
-    copy.from_string("active.__DEFAULT__");
+    copy.from_string("active.DEFAULT");
     EXPECT_EQ(active_default, copy);
 
     copy.from_string("active.FOO");

--- a/system_modes_examples/example_modes.yaml
+++ b/system_modes_examples/example_modes.yaml
@@ -40,6 +40,7 @@ actuation:
 manipulator:
   ros__parameters:
     type: node
+    defaultmode: DEFAULT
     modes:
       WEAK:
         ros__parameters:
@@ -47,7 +48,7 @@ manipulator:
       STRONG:
         ros__parameters:
           max_torque: 0.2
-      __DEFAULT__:
+      DEFAULT:
         ros__parameters:
           max_torque: 0.1
 

--- a/system_modes_examples/example_modes.yaml
+++ b/system_modes_examples/example_modes.yaml
@@ -7,8 +7,9 @@ actuation:
     parts:
       manipulator
       drive_base
+    defaultmode: DEFAULT
     modes:
-      __DEFAULT__:
+      DEFAULT:
         manipulator: inactive
         drive_base: active
       MODERATE:
@@ -40,21 +41,22 @@ manipulator:
   ros__parameters:
     type: node
     modes:
-      __DEFAULT__:
-        ros__parameters:
-          max_torque: 0.1
       WEAK:
         ros__parameters:
           max_torque: 0.1
       STRONG:
         ros__parameters:
           max_torque: 0.2
+      __DEFAULT__:
+        ros__parameters:
+          max_torque: 0.1
 
 drive_base:
   ros__parameters:
     type: node
+    defaultmode: NORMAL
     modes:
-      __DEFAULT__:
+      NORMAL:
         ros__parameters:
           max_speed: 0.1
           controller: PID

--- a/system_modes_examples/example_modes_with_namespace.yaml
+++ b/system_modes_examples/example_modes_with_namespace.yaml
@@ -4,12 +4,13 @@
 actuation:
   ros__parameters:
     type: system
+    defaultmode: DEFAULT
     parts:
       drive_base
       left/manipulator
       right/manipulator
     modes:
-      __DEFAULT__:
+      DEFAULT:
         drive_base: active
         left/manipulator: inactive
         right/manipulator: active.WEAK
@@ -25,8 +26,9 @@ actuation:
 left/manipulator:
   ros__parameters:
     type: node
+    defaultmode: DEFAULT
     modes:
-      __DEFAULT__:
+      DEFAULT:
         ros__parameters:
           max_torque: 0.1
       WEAK:
@@ -39,8 +41,9 @@ left/manipulator:
 drive_base:
   ros__parameters:
     type: node
+    defaultmode: NORMAL
     modes:
-      __DEFAULT__:
+      NORMAL:
         ros__parameters:
           max_speed: 0.1
           controller: PID
@@ -56,8 +59,9 @@ drive_base:
 right/manipulator:
   ros__parameters:
     type: node
+    defaultmode: DEFAULT
     modes:
-      __DEFAULT__:
+      DEFAULT:
         ros__parameters:
           max_torque: 0.11
       WEAK:

--- a/system_modes_examples/launch/example_system_start_drive_base.launch.py
+++ b/system_modes_examples/launch/example_system_start_drive_base.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
     drive_base_change_mode_to_DEFAULT = launch.actions.EmitEvent(
         event=launch_system_modes.events.ChangeMode(
             system_part_matcher=launch.events.matchers.matches_action(drive_base),
-            mode_name='__DEFAULT__',
+            mode_name='NORMAL',
         ))
 
     drive_base_change_mode_to_FAST = launch.actions.EmitEvent(
@@ -98,7 +98,7 @@ def generate_launch_description():
     on_DEFAULT_mode = launch.actions.RegisterEventHandler(
         launch_system_modes.event_handlers.OnModeChanged(
             target_system_part=drive_base,
-            goal_mode='__DEFAULT__',
+            goal_mode='NORMAL',
             entities=[drive_base_change_mode_to_FAST]))
 
     description = launch.LaunchDescription()

--- a/system_modes_examples/launch/example_system_started.launch.py
+++ b/system_modes_examples/launch/example_system_started.launch.py
@@ -84,7 +84,7 @@ def generate_launch_description():
     on_DEFAULT_mode = launch.actions.RegisterEventHandler(
         launch_system_modes.event_handlers.OnModeChanged(
             target_system_part=actuation,
-            goal_mode='__DEFAULT__',
+            goal_mode='DEFAULT',
             entities=[actuation_change_mode_to_PERFORMANCE]))
 
     description = launch.LaunchDescription()

--- a/system_modes_examples/launch/example_system_with_namespace.launch.py
+++ b/system_modes_examples/launch/example_system_with_namespace.launch.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 - for information on the respective copyright owner
+# see the NOTICE file and/or the repository https://github.com/micro-ROS/system_modes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ament_index_python.packages
+
+import launch
+import launch.actions
+import launch.launch_description_sources
+import launch.substitutions
+
+
+def generate_launch_description():
+    modelfile = (ament_index_python.packages.get_package_share_directory('system_modes_examples') +
+                 '/example_modes.yaml')
+
+    mode_manager = launch.actions.IncludeLaunchDescription(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
+            ament_index_python.packages.get_package_share_directory(
+                'system_modes') + '/launch/mode_manager.launch.py'),
+        launch_arguments={'modelfile': modelfile}.items())
+
+    drive_base = launch.actions.IncludeLaunchDescription(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
+            ament_index_python.packages.get_package_share_directory(
+                'system_modes_examples') + '/launch/drive_base.launch.py'),
+        launch_arguments={'modelfile': modelfile}.items())
+
+    manipulator = launch.actions.IncludeLaunchDescription(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
+            ament_index_python.packages.get_package_share_directory(
+                'system_modes_examples') + '/launch/manipulator.launch.py'),
+        launch_arguments={'modelfile': modelfile}.items())
+
+    description = launch.LaunchDescription()
+    description.add_action(mode_manager)
+    description.add_action(drive_base)
+    description.add_action(manipulator)
+
+    return description


### PR DESCRIPTION
This PR changes how default modes for parts (systems and nodes) are specified. The previous way of doing so, naming one of the modes `__DEFAULT__` is now deprecated, but still possible for backward compatibility.

Instead, each part now specifies an additional `defaultmode` argument in the SMH file as documented [here](https://github.com/micro-ROS/system_modes/tree/feature/flexible-default-mode/system_modes#system-modes) and exemplified [here](https://github.com/micro-ROS/system_modes/blob/feature/flexible-default-mode/system_modes_examples/example_modes.yaml#L10).