### PR TITLE
Add support for Windows

### DIFF
--- a/system_modes/CMakeLists.txt
+++ b/system_modes/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Differently from https://github.com/micro-ROS/system_modes/pull/82/files, this PR adds Windows support by exporing all symbols of the shared library, exactly how symbols are exported in Linux and macOS.